### PR TITLE
ARB AR Usability Improvements

### DIFF
--- a/demos/arb.md
+++ b/demos/arb.md
@@ -22,14 +22,14 @@ python arb.py hello
 |**delete**|*action*|Tap object to delete it.|
 |**lamp**|*toggle*|Turns a headlamp on/off.|
 |**lock**|*toggle*|Off=panel maintains relative world position; On=panel follows camera rotation. *(in development)*|
-|**model**|*action*|Allows GLTF model select; tap clipboard object to create it in place *(default=duck.glb)*.|
+|**model**|*action*|Allows GLTF model select; tap clipboard object to create it in place *(default=duck.glb)*. Models may be imported via the **-m** argument *(see below)*.|
 |**move**|*action*|Tap an object to show it in the clipboard, tap clipboard object to move it to that place.|
-|**nudge**|*action*|Tap an object to show yellow nudge-lines; tap a nudge-line to move the object to the nearest 0.1m. A yellow circle will also show x,z position on the floor (y=0).|
+|**nudge**|*action*|Allows mm, cm, dm, m granularity; tap an object to show yellow nudge-lines; tap a positive (red) or negative (blue) ball to nudge the object in that direction according to selected granularity *(default=mm)*. A yellow circle will also show x,z position on the floor (y=0). Nudge-lines expire after 30 seconds of inactivity.|
 |**occlude**|*action*|Allows occlusion on/off select; tap object to occlude it *(default=on)*.|
-|**redpill**|*toggle*|Reveals useful debug data: ***gridlines*** on the floor (y=0) can be seen from above and below, ***occlusion mask*** will show all occluded objects, ***object data*** mouse hover on an object will shows its position, rotation, and scale.
+|**redpill**|*toggle*|Reveals useful debug data: ***gridlines*** on the floor (y=0) can be seen from above and below, ***occlusion mask*** will show all occluded objects, ***object data*** mouse hover on an object will shows its position, rotation, and scale.|
 |**rename**|*action*|Allows typing a new name; tap an object to apply the new name.|
-|**rotate**|*action*|Allows object rotation. *(in development)*|
-|**scale**|*action*|Tap an object to show blue scale-lines; tap a scale-line to increase/decrease scale in 3 degrees 0.1m. Minimum 0.1m.
+|**rotate**|*action*|Allows 1°, 5°, 10°, 45°, 90° Euler angle granularity; tap an object to show orange rotate-lines; tap a positive (red) or negative (blue) ball to change object rotation according to selected granularity *(default=1°)*. Additional 6Dof lines will show degree of rotation. Rotate-lines expire after 30 seconds of inactivity.|
+|**scale**|*action*|Allows mm, cm, dm, m granularity; tap an object to show blue scale-lines; tap a positive (red) or negative (blue) ball to increase or decrease object scale according to selected granularity *(default=mm)*. Scale-lines expire after 30 seconds of inactivity.|
 |**stretch**|*action*|Allows altering scale in one of 6Dof. *(in development)*|
 |**wall**|*action*|Allows creation of a basic wall 0.1m thick; tap clipboard brick once with your AR device flush with one corner of the wall, and tap the second time at the opposing corner. Three alignment markers will appear for 2 minutes. *(in development)*|
 
@@ -44,7 +44,7 @@ There is a small temporary object resting on position 0,0,0 in the shape of a co
 ## Run Options
 
 ### Importing Models
-You can import a json-formatted manifest of GLTF models to use on the **model** control panel option *(under development)*. You can write your own, or use the example, `arb-manifest.json`.
+You can import a json-formatted manifest of GLTF models using the command argument **-m** to use on the **model** control panel option. You can write your own, or use the example, [arb-manifest.json](arb-manifest.json).
 ```
 python arb.py hello -m arb-manifest.json
 ```

--- a/demos/arblib.py
+++ b/demos/arblib.py
@@ -7,7 +7,6 @@
 
 import enum
 import json
-import string
 import urllib.request
 
 from scipy.spatial.transform import Rotation
@@ -18,9 +17,6 @@ CLICKLINE_LEN = 1  # meters
 CLICKLINE_SCL = (1, 1, 1)  # meters
 FLOOR_Y = 0.001  # meters
 GRIDLEN = 20  # meters
-NUDGE_INCR = 0.1  # meters
-SCALE_INCR = 0.1  # meters
-ROTATE_INCR = 5  # degrees
 CLIP_RADIUS = 1  # meters
 PANEL_RADIUS = 0.75  # meters
 LOCK_XOFF = 0  # quaternion vector
@@ -34,7 +30,7 @@ CLR_SELECT = (255, 255, 0)  # yellow
 CLR_GRID = (0, 255, 0)  # green
 CLR_ENABLED = (255, 255, 255)  # white
 CLR_DISABLED = (128, 128, 128)  # gray
-SCL_GLTF = (0.5, 0.5, 0.5)  # meters
+SCL_GLTF = (0.1, 0.1, 0.1)  # meters
 QUAT_VEC_RGTS = [-0.7, -0.5, 0, 0.5, 0.7, 1]
 QUAT_DEV_RGT = 0.075
 WALL_WIDTH = 0.1  # meters
@@ -51,14 +47,18 @@ GAZES = [
 
 def get_keys():
     keys = []
-    keys.extend(list(string.digits))
-    keys.extend(list(string.ascii_lowercase))
+    keys.extend(list("1234567890"))
+    keys.extend(list("qwertyuiop"))
+    keys.extend(list("asdfghjkl_"))
+    keys.extend(list("zxcvbnm"))
     keys.append('back')
     return keys
 
 
 KEYS = get_keys()
 BOOLS = ["on", "off"]
+METERS = ["mm", "cm", "dm", "m"]
+DEGREES = ["1", "5", "10", "45", "90"]
 COLORS = ["ffffff", "ff0000", "ffa500", "ffff00", "00ff00",
           "0000ff", "4b0082", "800080", "a52a2a", "000000"]
 SHAPES = [arena.Shape.sphere.value,
@@ -361,14 +361,12 @@ def set_clipboard(camname,
                   obj_type=arena.Shape.sphere,
                   scale=(0.05, 0.05, 0.05),
                   color=CLR_ENABLED,
-                  rotation=(-0.1, -0.1, 0, 1),  # rotation for visibility
                   url=""):
-    return arena.Object(
+    clip = arena.Object(
         objName=("clipboard_" + camname),
         objType=obj_type,
         color=color,
         location=(0, 0, -CLIP_RADIUS),
-        rotation=rotation,
         parent=camname,
         scale=scale,
         data=('{"material":{"transparent":true,"opacity":0.4}}'),
@@ -376,6 +374,19 @@ def set_clipboard(camname,
         clickable=True,
         callback=callback,
     )
+    target_scale = (clip.scale[0]/10, clip.scale[1]/10, clip.scale[2]/10)
+    arena.Object(
+        objName=("cliptarget_" + camname),
+        objType=arena.Shape.sphere,
+        color=color,
+        location=(0, 0, 0),
+        parent=clip.objName,
+        scale=target_scale,
+        data=('{"material":{"transparent":true,"opacity":0.4}}'),
+        clickable=True,
+        callback=callback,
+    )
+    return clip
 
 
 def update_persisted_obj(realm, scene, object_id, label,


### PR DESCRIPTION
- added granularity options for nudge/scale/rotate clicklines
- used red for increase, blue for decrease clicklines
- reordered rename keys to qwerty-style
- fixed AR click to place gltf model
- replaced clicklines with thickline since line messes up mouse events
- updated docs
- (known issue: AR reb/blue balls can be clicked, but thicklines unseen)