### PR TITLE
Add token to persistence calls

### DIFF
--- a/arena/arena.py
+++ b/arena/arena.py
@@ -250,7 +250,7 @@ def agran(float_num):
 
 def get_network_persisted_obj(object_id, broker, scene):
     # pass token to persist
-    data = auth._urlopen(
+    data = auth.urlopen(
         url=f'https://{broker}/persist/{scene}/{object_id}', creds=True)
     output = json.loads(data)
     return output
@@ -258,7 +258,7 @@ def get_network_persisted_obj(object_id, broker, scene):
 
 def get_network_persisted_scene(broker, scene):
     # pass token to persist
-    data = auth._urlopen(
+    data = auth.urlopen(
         url=f'https://{broker}/persist/{scene}', creds=True)
     output = json.loads(data)
     return output

--- a/arena/arena.py
+++ b/arena/arena.py
@@ -248,6 +248,22 @@ def agran(float_num):
     return round(float_num, 3)
 
 
+def get_network_persisted_obj(object_id, broker, scene):
+    # pass token to persist
+    data = auth._urlopen(
+        url=f'https://{broker}/persist/{scene}/{object_id}', creds=True)
+    output = json.loads(data)
+    return output
+
+
+def get_network_persisted_scene(broker, scene):
+    # pass token to persist
+    data = auth._urlopen(
+        url=f'https://{broker}/persist/{scene}', creds=True)
+    output = json.loads(data)
+    return output
+
+
 class Physics(enum.Enum):
     none = "none"
     static = "static"

--- a/arena/auth.py
+++ b/arena/auth.py
@@ -17,8 +17,8 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 
 debug_toggle = False
 _scopes = ["openid",
-          "https://www.googleapis.com/auth/userinfo.profile",
-          "https://www.googleapis.com/auth/userinfo.email"]
+           "https://www.googleapis.com/auth/userinfo.profile",
+           "https://www.googleapis.com/auth/userinfo.email"]
 _user_gauth_path = f'{str(Path.home())}/.arena_google_auth'
 _user_mqtt_path = f'{str(Path.home())}/.arena_mqtt_auth'
 _local_mqtt_path = f'.arena_mqtt_auth'
@@ -27,6 +27,7 @@ _mqtt_token = {}
 
 def authenticate(realm, scene, broker, webhost, debug=False):
     global debug_toggle
+    global _mqtt_token
     debug_toggle = debug
     print("Signing in to the ARENA...")
 
@@ -131,14 +132,15 @@ def _get_mqtt_token(broker, realm, scene, user, id_token):
     data = query_string.encode("ascii")
     return urlopen(url, data)
 
-"""
-urlopen is for ARENA URL connections.
-url: the url to POST/GET.
-data: None for GET, add params for POST.
-creds: True to pass the MQTT token as a cookie.
-"""
+
 def urlopen(url, data=None, creds=False):
+    """ urlopen is for ARENA URL connections.
+    url: the url to POST/GET.
+    data: None for GET, add params for POST.
+    creds: True to pass the MQTT token as a cookie.
+    """
     global debug_toggle
+    global _mqtt_token
     try:
         req = request.Request(url)
         if creds:

--- a/arena/auth.py
+++ b/arena/auth.py
@@ -16,13 +16,13 @@ from google.auth.transport.requests import AuthorizedSession, Request
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 debug_toggle = False
-scopes = ["openid",
+_scopes = ["openid",
           "https://www.googleapis.com/auth/userinfo.profile",
           "https://www.googleapis.com/auth/userinfo.email"]
-user_gauth_path = f'{str(Path.home())}/.arena_google_auth'
-user_mqtt_path = f'{str(Path.home())}/.arena_mqtt_auth'
-local_mqtt_path = f'.arena_mqtt_auth'
-mqtt_token = {}
+_user_gauth_path = f'{str(Path.home())}/.arena_google_auth'
+_user_mqtt_path = f'{str(Path.home())}/.arena_mqtt_auth'
+_local_mqtt_path = f'.arena_mqtt_auth'
+_mqtt_token = {}
 
 
 def authenticate(realm, scene, broker, webhost, debug=False):
@@ -32,14 +32,14 @@ def authenticate(realm, scene, broker, webhost, debug=False):
 
     # TODO: remove local check after ARTS supports mqtt_token passing
     # check for local mqtt_token first
-    if os.path.exists(local_mqtt_path):
+    if os.path.exists(_local_mqtt_path):
         print("Using local MQTT token.")
-        f = open(local_mqtt_path, "r")
+        f = open(_local_mqtt_path, "r")
         mqtt_json = f.read()
         f.close()
         # TODO: check token expiration
-        mqtt_token = json.loads(mqtt_json)
-        return mqtt_token
+        _mqtt_token = json.loads(mqtt_json)
+        return _mqtt_token
 
     # begin authentication flow
     creds = None
@@ -50,9 +50,9 @@ def authenticate(realm, scene, broker, webhost, debug=False):
         print("Console-only login. {0}".format(err))
 
     # store the user's access and refresh tokens
-    if os.path.exists(user_gauth_path):
+    if os.path.exists(_user_gauth_path):
         print("Using cached Google authentication.")
-        with open(user_gauth_path, 'rb') as token:
+        with open(_user_gauth_path, 'rb') as token:
             creds = pickle.load(token)
         session = AuthorizedSession(creds)
     # if no credentials available, let the user log in.
@@ -63,19 +63,19 @@ def authenticate(realm, scene, broker, webhost, debug=False):
             session = AuthorizedSession(creds)
         else:
             print("Requesting new Google authentication.")
-            gauth_json = get_gauthid(webhost)
+            gauth_json = _get_gauthid(webhost)
             flow = InstalledAppFlow.from_client_config(
-                json.loads(gauth_json), scopes)
+                json.loads(gauth_json), _scopes)
             if browser:
                 # TODO: select best client port to avoid likely conflicts
                 creds = flow.run_local_server(port=8989)
             else:
                 creds = flow.run_console()
             session = flow.authorized_session()
-        with open(user_gauth_path, 'wb') as token:
+        with open(_user_gauth_path, 'wb') as token:
             # save the credentials for the next run
             pickle.dump(creds, token)
-        os.chmod(user_gauth_path, 0o600)  # set user-only perms.
+        os.chmod(_user_gauth_path, 0o600)  # set user-only perms.
 
     id_token = creds.id_token
     profile_info = session.get(
@@ -89,8 +89,8 @@ def authenticate(realm, scene, broker, webhost, debug=False):
 
         # TODO: permissions may change by owner or admin,
         # for now, get a fresh mqtt_token each time
-        # if os.path.exists(user_mqtt_path):
-        #     f = open(user_mqtt_path, "r")
+        # if os.path.exists(_user_mqtt_path):
+        #     f = open(_user_mqtt_path, "r")
         #     mqtt_json = f.read()
         #     f.close()
         # # TODO: check token expiration
@@ -98,24 +98,24 @@ def authenticate(realm, scene, broker, webhost, debug=False):
         # if no credentials available, get them.
         if not mqtt_json:
             print("Using remote-authenticated MQTT token.")
-            mqtt_json = get_mqtt_token(broker, realm, scene, user, id_token)
+            mqtt_json = _get_mqtt_token(broker, realm, scene, user, id_token)
             # save mqtt_token
-            with open(user_mqtt_path, mode="w") as d:
+            with open(_user_mqtt_path, mode="w") as d:
                 d.write(mqtt_json)
-            os.chmod(user_mqtt_path, 0o600)  # set user-only perms.
+            os.chmod(_user_mqtt_path, 0o600)  # set user-only perms.
 
     # end authentication flow
-    mqtt_token = json.loads(mqtt_json)
-    return mqtt_token
+    _mqtt_token = json.loads(mqtt_json)
+    return _mqtt_token
 
 
 # TODO: will be deprecated after using arena-account
-def get_gauthid(webhost):
+def _get_gauthid(webhost):
     url = f'https://{webhost}/conf/gauth.json'
-    return _urlopen(url)
+    return urlopen(url)
 
 
-def get_mqtt_token(broker, realm, scene, user, id_token):
+def _get_mqtt_token(broker, realm, scene, user, id_token):
     url = f'https://{broker}/auth/'
     if broker == 'oz.andrew.cmu.edu':
         # TODO: remove this workaround for non-auth broker
@@ -129,15 +129,20 @@ def get_mqtt_token(broker, realm, scene, user, id_token):
     }
     query_string = parse.urlencode(params)
     data = query_string.encode("ascii")
-    return _urlopen(url, data)
+    return urlopen(url, data)
 
-
-def _urlopen(url, data=None, creds=False):
+"""
+urlopen is for ARENA URL connections.
+url: the url to POST/GET.
+data: None for GET, add params for POST.
+creds: True to pass the MQTT token as a cookie.
+"""
+def urlopen(url, data=None, creds=False):
     global debug_toggle
     try:
         req = request.Request(url)
         if creds:
-            req.add_header("Cookie", f"mqtt_token={mqtt_token['token']}")
+            req.add_header("Cookie", f"mqtt_token={_mqtt_token['token']}")
         if debug_toggle:
             context = ssl.create_default_context()
             context.check_hostname = False
@@ -152,10 +157,10 @@ def _urlopen(url, data=None, creds=False):
 
 
 def signout():
-    if os.path.exists(user_gauth_path):
-        os.remove(user_gauth_path)
-    if os.path.exists(user_mqtt_path):
-        os.remove(user_mqtt_path)
+    if os.path.exists(_user_gauth_path):
+        os.remove(_user_gauth_path)
+    if os.path.exists(_user_mqtt_path):
+        os.remove(_user_mqtt_path)
     print("Signed out of the ARENA.")
 
 

--- a/tools/arb/arb.py
+++ b/tools/arb/arb.py
@@ -125,7 +125,7 @@ def handle_clickline_event(event, mode):
         return None, None, None
     if USERS[event.source].mode != mode:
         return None, None, None
-    pobjs = arblib.get_network_persisted_obj(object_id, BROKER, SCENE)
+    pobjs = arena.get_network_persisted_obj(object_id, BROKER, SCENE)
     if not pobjs:
         return None, None, None
     obj = arblib.ObjectPersistence(pobjs[0])
@@ -339,10 +339,10 @@ def show_redpill_scene(enabled):
                          line=arena.Line((x, y, -glen), (x, y, glen), 1, hcolor))
         else:
             arblib.delete_obj(REALM, SCENE, name)
-    pobjs = arblib.get_network_persisted_scene(BROKER, SCENE)
+    pobjs = arena.get_network_persisted_scene(BROKER, SCENE)
     for pobj in pobjs:
         obj = arblib.ObjectPersistence(pobj)
-        # show occulded objects
+        # show occluded objects
         if obj.transparent_occlude:
             name = "redpill_" + obj.object_id
             if enabled:
@@ -365,7 +365,7 @@ def show_redpill_scene(enabled):
 def do_rename(camname, old_id, new_id):
     if new_id == old_id:
         return
-    pobjs = arblib.get_network_persisted_obj(old_id, BROKER, SCENE)
+    pobjs = arena.get_network_persisted_obj(old_id, BROKER, SCENE)
     if not pobjs:
         return
     data = json.dumps(pobjs[0]["attributes"])
@@ -377,7 +377,7 @@ def do_rename(camname, old_id, new_id):
 
 def show_redpill_obj(camname, object_id):
     # any scene changes must not persist
-    pobjs = arblib.get_network_persisted_obj(object_id, BROKER, SCENE)
+    pobjs = arena.get_network_persisted_obj(object_id, BROKER, SCENE)
     if not pobjs:
         return
     obj = arblib.ObjectPersistence(pobjs[0])
@@ -387,7 +387,7 @@ def show_redpill_obj(camname, object_id):
 
 
 def do_move_select(camname, object_id):
-    pobjs = arblib.get_network_persisted_obj(object_id, BROKER, SCENE)
+    pobjs = arena.get_network_persisted_obj(object_id, BROKER, SCENE)
     if not pobjs:
         return
     obj = arblib.ObjectPersistence(pobjs[0])
@@ -414,7 +414,7 @@ def do_nudge_select(camname, objid, position=None):
     delim = "_"+Mode.NUDGE.value+"_"
     callback = nudgeline_callback
     if not position:
-        pobjs = arblib.get_network_persisted_obj(objid, BROKER, SCENE)
+        pobjs = arena.get_network_persisted_obj(objid, BROKER, SCENE)
         if not pobjs:
             return
         obj = arblib.ObjectPersistence(pobjs[0])
@@ -433,7 +433,7 @@ def do_scale_select(camname, objid, scale=None):
     delim = "_"+Mode.SCALE.value+"_"
     callback = scaleline_callback
     if not scale:
-        pobjs = arblib.get_network_persisted_obj(objid, BROKER, SCENE)
+        pobjs = arena.get_network_persisted_obj(objid, BROKER, SCENE)
         if not pobjs:
             return
         obj = arblib.ObjectPersistence(pobjs[0])
@@ -451,7 +451,7 @@ def do_stretch_select(camname, objid, scale=None):
     delim = "_"+Mode.STRETCH.value+"_"
     callback = stretchline_callback
     if not scale:
-        pobjs = arblib.get_network_persisted_obj(objid, BROKER, SCENE)
+        pobjs = arena.get_network_persisted_obj(objid, BROKER, SCENE)
         if not pobjs:
             return
         obj = arblib.ObjectPersistence(pobjs[0])
@@ -478,13 +478,13 @@ def do_rotate_select(camname, objid, rotation=None):
     delim = "_"+Mode.ROTATE.value+"_"
     callback = rotateline_callback
     if not rotation:
-        pobjs = arblib.get_network_persisted_obj(objid, BROKER, SCENE)
+        pobjs = arena.get_network_persisted_obj(objid, BROKER, SCENE)
         if not pobjs:
             return
         obj = arblib.ObjectPersistence(pobjs[0])
         position = obj.position
         rotation = obj.rotation
-        # rotate object + or - on 3 axis, plus show orginal axis as after
+        # rotate object + or - on 3 axis, plus show original axis as after
         # effect
         make_clickline("x", 1, objid, position, delim, color, callback, True)
         make_clickline("y", 1, objid, position, delim, color, callback, True)

--- a/tools/arb/arblib.py
+++ b/tools/arb/arblib.py
@@ -8,12 +8,10 @@
 import enum
 import json
 import re
-import urllib.request
-
-import webcolors
-from scipy.spatial.transform import Rotation
 
 import arena
+import webcolors
+from scipy.spatial.transform import Rotation
 
 CLICKLINE_LEN = 1  # meters
 CLICKLINE_SCL = (1, 1, 1)  # meters
@@ -553,19 +551,3 @@ def probable_quat(num):
     if abs(num - closest) < QUAT_DEV_RGT:
         return closest
     return num
-
-
-# TODO: pass in mqtt_token to persist
-def get_network_persisted_obj(object_id, broker, scene):
-    data = urllib.request.urlopen(
-        'https://' + broker + '/persist/' + scene + '/' + object_id).read()
-    output = json.loads(data)
-    return output
-
-
-# TODO: pass in mqtt_token to persist
-def get_network_persisted_scene(broker, scene):
-    data = urllib.request.urlopen(
-        'https://' + broker + '/persist/' + scene).read()
-    output = json.loads(data)
-    return output


### PR DESCRIPTION
- Updated auth lib `urlopen(creds=False)` to pass MQTT token when `creds=True`.
- [arb] Moved persistence calls from arblib to arena lib.
- Fixes #39. 