### PR TITLE
remove realm default, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python hello.py
 ```python
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_box():

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ See [ARENA Documentation: Python](https://arena.conix.io/content/python/).
 from arena import *
 
 # create library
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once # make this function a task that runs once at startup
 def main():

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -138,7 +138,7 @@ def user_join_callback(scene, cam, msg):
     cam_state = CameraState(cam)
     cam_states += [cam_state]
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 scene.user_join_callback = user_join_callback
 
 @scene.run_forever(interval_ms=200)

--- a/docs/beginner.md
+++ b/docs/beginner.md
@@ -24,9 +24,9 @@ from arena import *
 ```python
 arena = Scene()
 ```
-You can also pass host, realm, and scene as arguments, if you don't want to use enviornmental variables. These *must* be keyword arguments:
+You can also pass host and scene as arguments, if you don't want to use environmental variables. These *must* be keyword arguments:
 ```python
-scene = Scene(host=[host], realm=[realm], scene=[scene])
+scene = Scene(host=[host], scene=[scene])
 ```
 Note: ARENA-py will always favor environmental variables over arguments.
 
@@ -66,7 +66,7 @@ Now, go into the scene to see your box!
 from arena import *
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 def main():
     # make a box

--- a/docs/intermediate.md
+++ b/docs/intermediate.md
@@ -55,7 +55,7 @@ Now, go into the scene to see your box move with text!
 from arena import *
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 # make a box
 box = Box(object_id="my_box", position=Position(0,4,-2), scale=Scale(2,2,2))

--- a/docs/novice.md
+++ b/docs/novice.md
@@ -28,7 +28,7 @@ scene.delete_object(box)
 from arena import *
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_async
 async def func():

--- a/examples/addtopic.py
+++ b/examples/addtopic.py
@@ -19,7 +19,7 @@ def secondary_callback(msg):
 
 
 # subscribe to objects
-scene = Scene(host="arenaxr.org", realm="realm", scene="example", on_msg_callback=objects_callback)
+scene = Scene(host="arenaxr.org", scene="example", on_msg_callback=objects_callback)
 
 @scene.run_async
 async def test():

--- a/examples/anim-test.py
+++ b/examples/anim-test.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org",realm="realm",scene="example")
+scene = Scene(host="arenaxr.org",scene="example")
 
 x=0
 

--- a/examples/attributes/animation.py
+++ b/examples/attributes/animation.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 my_torus = Torus(
     object_id="my_torus",

--- a/examples/attributes/animation_mixer.py
+++ b/examples/attributes/animation_mixer.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 xr_logo = GLTF(
     object_id="xr-logo",

--- a/examples/attributes/clickable.py
+++ b/examples/attributes/clickable.py
@@ -1,7 +1,7 @@
 from arena import *
 import random
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 def click(scene, evt, msg):
     if evt.type == "mouseup":

--- a/examples/attributes/color.py
+++ b/examples/attributes/color.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 color = (100,200,100) # Color(100,200,100) works too
 

--- a/examples/attributes/goto_url.py
+++ b/examples/attributes/goto_url.py
@@ -2,7 +2,7 @@
 #
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 print("Three clickable URL boxs targetted to different windows" )
 

--- a/examples/attributes/material.py
+++ b/examples/attributes/material.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 material = Material(opacity=0.3, transparent=True)
 

--- a/examples/attributes/morph.py
+++ b/examples/attributes/morph.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 xr_logo = GLTF(
     object_id="xr-logo",

--- a/examples/attributes/physics_impulse.py
+++ b/examples/attributes/physics_impulse.py
@@ -1,7 +1,7 @@
 from arena import *
 import random
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_bouncy_ball():

--- a/examples/attributes/position.py
+++ b/examples/attributes/position.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 position = (1,2,-3) # Position(1,2,-3) works too
 

--- a/examples/attributes/rotation.py
+++ b/examples/attributes/rotation.py
@@ -1,7 +1,7 @@
 import math
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 rotation_euler = (45,0,45) # Rotation(45,0,45) works too
 rotation_quaternion = (0,0,1,1) # Rotation(0,0,1,1) works too

--- a/examples/attributes/scale.py
+++ b/examples/attributes/scale.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 scale = (1,2,1) # Scale(1,2,1) works too
 

--- a/examples/attributes/sound.py
+++ b/examples/attributes/sound.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 sound = Sound(positional=True, poolSize=1, autoplay=True, src="store/users/wiselab/audio/september.mp3")
 

--- a/examples/attributes/text_input.py
+++ b/examples/attributes/text_input.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arena-dev1.conix.io", realm="realm", scene="example")
+scene = Scene(host="arena-dev1.conix.io", scene="example")
 
 def evt_handler(scene, evt, msg):
     if evt.type == "textinput":

--- a/examples/camera-child.py
+++ b/examples/camera-child.py
@@ -3,7 +3,7 @@
 '''
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 def user_join_callback(scene, cam, msg):
     if "camera" in cam.object_id:

--- a/examples/camera-print.py
+++ b/examples/camera-print.py
@@ -45,7 +45,7 @@ def user_join_callback(scene, cam, msg):
     cam_state = CameraState(cam)
     cam_states += [cam_state]
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 scene.user_join_callback = user_join_callback
 
 @scene.run_forever(interval_ms=200)

--- a/examples/camera-tracer.py
+++ b/examples/camera-tracer.py
@@ -37,7 +37,7 @@ def user_join_callback(scene, cam, msg):
     cam_state = CameraState(cam)
     cam_states += [cam_state]
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 scene.user_join_callback = user_join_callback
 
 @scene.run_forever(interval_ms=200)

--- a/examples/earth-moon.py
+++ b/examples/earth-moon.py
@@ -4,7 +4,7 @@
 '''
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def main():

--- a/examples/green-boxes.py
+++ b/examples/green-boxes.py
@@ -3,7 +3,7 @@ import random
 import time
 import sys
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 color = (0, 255, 0)
 

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_box():

--- a/examples/laser-pointer.py
+++ b/examples/laser-pointer.py
@@ -1,7 +1,7 @@
 from arena import *
 import random
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 def click(scene, evt, msg):
     if evt.type == "mousedown":

--- a/examples/objects/box.py
+++ b/examples/objects/box.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_box():

--- a/examples/objects/circle.py
+++ b/examples/objects/circle.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_circle():

--- a/examples/objects/cone.py
+++ b/examples/objects/cone.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_cone():

--- a/examples/objects/cylinder.py
+++ b/examples/objects/cylinder.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_cylinder():

--- a/examples/objects/dodecahedron.py
+++ b/examples/objects/dodecahedron.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_dod():

--- a/examples/objects/gltf.py
+++ b/examples/objects/gltf.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_xr_logo():

--- a/examples/objects/icosahedron.py
+++ b/examples/objects/icosahedron.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_iso():

--- a/examples/objects/image.py
+++ b/examples/objects/image.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 image_url = "https://raw.githubusercontent.com/conix-center/ARENA-core/master/images/conix-face-white.jpg"
 

--- a/examples/objects/landmarks.py
+++ b/examples/objects/landmarks.py
@@ -4,7 +4,7 @@
 
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 object_id = "the_box"
 

--- a/examples/objects/light.py
+++ b/examples/objects/light.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_light():

--- a/examples/objects/line.py
+++ b/examples/objects/line.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 start = (0,0,-3)
 end = (10,10,-10)

--- a/examples/objects/octahedron.py
+++ b/examples/objects/octahedron.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_oct():

--- a/examples/objects/plane.py
+++ b/examples/objects/plane.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_plane():

--- a/examples/objects/ring.py
+++ b/examples/objects/ring.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_ring():

--- a/examples/objects/sphere.py
+++ b/examples/objects/sphere.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_sphere():

--- a/examples/objects/tetrahedron.py
+++ b/examples/objects/tetrahedron.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_tet():

--- a/examples/objects/text.py
+++ b/examples/objects/text.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_text():

--- a/examples/objects/thickline.py
+++ b/examples/objects/thickline.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 start = (0,0,-3)
 end = (10,10,-10)

--- a/examples/objects/torus.py
+++ b/examples/objects/torus.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_torus():

--- a/examples/objects/torus_knot.py
+++ b/examples/objects/torus_knot.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_torusknot():

--- a/examples/objects/triangle.py
+++ b/examples/objects/triangle.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_once
 def make_triangle():

--- a/examples/pinata.py
+++ b/examples/pinata.py
@@ -8,18 +8,18 @@ from arena import *
 import random
 import time
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="pinata")
+scene = Scene(host="arenaxr.org", scene="pinata")
 
 # Constants used to define operations
 RESPAWN_X_MIN = -50
 RESPAWN_X_MAX = 50
 RESPAWN_Z_MIN = -50
-RESPAWN_Z_MAX = 50 
+RESPAWN_Z_MAX = 50
 RESPAWN_Y = 10          # respawn at exactly this Y position
 HIT_RELOAD=10           # how many hits does it take
-#G_ACCEL = -9.8          
-#HIT_IMPULSE = 20        
-G_ACCEL = -19.8          
+#G_ACCEL = -9.8
+#HIT_IMPULSE = 20
+G_ACCEL = -19.8
 HIT_IMPULSE = 20        # Velocity added to hit
 GROUND_LEVEL = -1       # Ground level for pseudo-physics
 
@@ -40,7 +40,7 @@ APPLAUSE_SOUND_PATH="https://www.dropbox.com/s/3k9fin95z6nbex9/applause.wav?dl=0
 # location of the pinata
 pinata_loc = [0,0,0]
 pinata_state = IDLE  # 0-still, 1-moving, 2-explode, 3-waiting to restart
-hit_counter = HIT_RELOAD 
+hit_counter = HIT_RELOAD
 # time and velocity globals for physics
 t=0
 vy=0
@@ -55,13 +55,13 @@ def explode():
     scene.update_object(pinata)
     for i in range(50):
         rand_offset = (random.random()-0.5)/5
-        colorBox = Box(position=(pinata_loc[0]+rand_offset, pinata_loc[1]+rand_offset, pinata_loc[2]+rand_offset),scale=Scale(.5,.5,.5),ttl=15,physics=Physics(type="dynamic")) 
-        scene.add_object(colorBox) 
+        colorBox = Box(position=(pinata_loc[0]+rand_offset, pinata_loc[1]+rand_offset, pinata_loc[2]+rand_offset),scale=Scale(.5,.5,.5),ttl=15,physics=Physics(type="dynamic"))
+        scene.add_object(colorBox)
     explode_sound = Sound(src=EXPLODE_SOUND_PATH,positional=True,autoplay=True,poolSize=1 )
-    explode_sound_obj = Box(sound=explode_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10) 
+    explode_sound_obj = Box(sound=explode_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10)
     scene.add_object(explode_sound_obj)
     applause_sound = Sound(src=APPLAUSE_SOUND_PATH,positional=True,autoplay=True,poolSize=1 )
-    applause_sound_obj = Box(sound=applause_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10) 
+    applause_sound_obj = Box(sound=applause_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10)
     scene.add_object(applause_sound_obj)
 
 
@@ -87,7 +87,7 @@ def click(scene, evt, msg):
         scene.update_object(hit_text)
 
         hit_sound = Sound(src=HIT_SOUND_PATH,positional=True,autoplay=True,poolSize=10 )
-        hit_sound_obj = Box(sound=hit_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1) 
+        hit_sound_obj = Box(sound=hit_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1)
         scene.add_object(hit_sound_obj)
 
         print("Hit Counter: " + str(hit_counter))
@@ -99,10 +99,10 @@ def click(scene, evt, msg):
 def game_reset():
     global hit_counter,pinata_loc,pinata_state,pinata,hit_text,vy,t
     witch_sound = Sound(src=WITCH_SOUND_PATH,positional=True,autoplay=True,poolSize=1 )
-    witch_sound_obj = Box(sound=witch_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10) 
+    witch_sound_obj = Box(sound=witch_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10)
     scene.add_object(witch_sound_obj)
     hit_counter=HIT_RELOAD
-    pinata_loc=[random.randrange(RESPAWN_X_MIN,RESPAWN_X_MAX),RESPAWN_Y,random.randrange(RESPAWN_Z_MIN,RESPAWN_Z_MAX)]   
+    pinata_loc=[random.randrange(RESPAWN_X_MIN,RESPAWN_X_MAX),RESPAWN_Y,random.randrange(RESPAWN_Z_MIN,RESPAWN_Z_MAX)]
     pinata.update_attributes(position=pinata_loc)
     scene.update_object(pinata)
     hit_text.update_attributes(text=str(hit_counter))
@@ -174,12 +174,12 @@ def main_loop():
         # Each time the pinata hits the ground, it bounces
         # This section converts some amount of velocity at impact to be rebounce
         # This section also caps small velocities to stop infinite bouncing
-        if y<=GROUND_LEVEL+.2:  
+        if y<=GROUND_LEVEL+.2:
             if vy>2 or  vy<-2:
                 vy=-.5*vy   # This is the bounce input, where the ground returns half the velocity
                 y = GROUND_LEVEL
                 boing_sound = Sound(src=BOUNCE_SOUND_PATH,positional=True,autoplay=True,poolSize=10 )
-                boing_sound_obj = Box(sound=boing_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1) 
+                boing_sound_obj = Box(sound=boing_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1)
                 scene.add_object(boing_sound_obj)
             else:
                 # If the velocity is low enough, lets just cap it

--- a/examples/teleporter.py
+++ b/examples/teleporter.py
@@ -49,7 +49,7 @@ class Teleporter(Object):
         self.scene.add_object(self.dest_text)
 
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 teleporter = Teleporter(
                     scene=scene,

--- a/examples/tutorial-agent.py
+++ b/examples/tutorial-agent.py
@@ -1,7 +1,7 @@
 from arena import *
 import random, math
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 model_url = "/store/users/wiselab/models/FaceCapHeadGeneric/FaceCapHeadGeneric.gltf"
 avatar = GLTF(

--- a/examples/tutorial/advanced.py
+++ b/examples/tutorial/advanced.py
@@ -36,7 +36,7 @@ def user_join_callback(scene, cam, msg):
     cam_state = CameraState(cam)
     cam_states += [cam_state]
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 scene.user_join_callback = user_join_callback
 
 @scene.run_forever(interval_ms=200)

--- a/examples/tutorial/beginner.py
+++ b/examples/tutorial/beginner.py
@@ -1,7 +1,7 @@
 from arena import *
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 def main():
     # make a box

--- a/examples/tutorial/intermediate.py
+++ b/examples/tutorial/intermediate.py
@@ -1,7 +1,7 @@
 from arena import *
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 # make a box
 box = Box(object_id="my_box", position=Position(0,4,-2), scale=Scale(2,2,2))

--- a/examples/tutorial/novice.py
+++ b/examples/tutorial/novice.py
@@ -1,7 +1,7 @@
 from arena import *
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 @scene.run_async
 async def func():

--- a/system-tests/auto-updates-helper.py
+++ b/system-tests/auto-updates-helper.py
@@ -7,7 +7,7 @@ from arena import *
 import random
 
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 box = Box(object_id="box", position=(0,2,-1), rotation=(0,0,0), scale=(2,2,2), material=Material(transparent=True, opacity=1))
 

--- a/system-tests/auto-updates.py
+++ b/system-tests/auto-updates.py
@@ -7,7 +7,7 @@ from arena import *
 import random
 
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 def evt_handler(scene, evt, msg): # should magically be able to click, thanks to auto-updates-helper.py...
     print("clicked")

--- a/system-tests/balls.py
+++ b/system-tests/balls.py
@@ -5,7 +5,7 @@
 from arena import *
 import random
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 
 def rando():

--- a/system-tests/custom-topic.py
+++ b/system-tests/custom-topic.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 CUSTOM_TOPIC = "$NETWORK"
 

--- a/system-tests/errors.py
+++ b/system-tests/errors.py
@@ -6,7 +6,7 @@
 from arena import Scene
 
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="example")
+scene = Scene(host="arenaxr.org", scene="example")
 
 
 @scene.run_once

--- a/system-tests/get-persisted-objs.py
+++ b/system-tests/get-persisted-objs.py
@@ -4,7 +4,7 @@
 
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 @scene.run_once
 def main():

--- a/system-tests/headbanger.py
+++ b/system-tests/headbanger.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from arena import *
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="headbanger", )
+scene = Scene(host="arenaxr.org", scene="headbanger", )
 # Create models
 
 # How Many heads?

--- a/system-tests/move-camera.py
+++ b/system-tests/move-camera.py
@@ -13,7 +13,7 @@ def user_join_callback(camera):
     print(f"User found: {camera.displayName} [object_id={camera.object_id}]")
 
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 scene.user_join_callback = user_join_callback
 
 # box = Box(object_id="box")

--- a/system-tests/move-cubes.py
+++ b/system-tests/move-cubes.py
@@ -7,7 +7,7 @@ from arena import *
 import random
 
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 
 music_on = False

--- a/system-tests/persist1-create.py
+++ b/system-tests/persist1-create.py
@@ -14,7 +14,7 @@ from arena import *
 
 
 program1 = Scene(host="arenaxr.org",
-                 realm="realm", scene="persist-test")
+                 scene="persist-test")
 
 
 @program1.run_once

--- a/system-tests/persist2-discover.py
+++ b/system-tests/persist2-discover.py
@@ -21,7 +21,7 @@ def on_msg_callback(scene, obj, msg):
 
 
 program2 = Scene(
-    host="arenaxr.org", realm="realm", scene="persist-test",
+    host="arenaxr.org", scene="persist-test",
     on_msg_callback=on_msg_callback,
 )
 

--- a/system-tests/rotate-cube.py
+++ b/system-tests/rotate-cube.py
@@ -7,7 +7,7 @@ import random
 
 
 # start ARENA client
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 box = Box(object_id="box", position=(0,4,-2), scale=Scale(2,2,2), rotation=(0,0,0), color=Color(0,0,0))
 scene.add_object(box)

--- a/system-tests/scene-callbacks.py
+++ b/system-tests/scene-callbacks.py
@@ -14,7 +14,7 @@ def delete_obj_callback(scene, obj, msg):
     print("delete", obj, obj.object_id)
 
 scene = Scene(
-              host="arenaxr.org", realm="realm", scene="test",
+              host="arenaxr.org", scene="test",
               new_obj_callback=new_obj_callback,
               on_msg_callback=on_msg_callback,
               delete_obj_callback=delete_obj_callback

--- a/system-tests/tasks.py
+++ b/system-tests/tasks.py
@@ -1,7 +1,7 @@
 from arena import *
 
 # start ARENA client
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 @scene.run_once
 def f1():

--- a/system-tests/trans-cubes.py
+++ b/system-tests/trans-cubes.py
@@ -7,7 +7,7 @@ import random
 import time
 
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 
 def randmove():

--- a/system-tests/user-callbacks.py
+++ b/system-tests/user-callbacks.py
@@ -10,7 +10,7 @@ def user_join_callback(scene, camera, msg):
 def user_left_callback(scene, camera, msg):
     print(f"User left: {camera.displayName} [object_id={camera.object_id}]")
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 scene.user_join_callback = user_join_callback
 scene.user_left_callback = user_left_callback
 

--- a/tools/avatar/avatar.py
+++ b/tools/avatar/avatar.py
@@ -13,7 +13,7 @@ from arena import *
 
 
 avatars = {}
-scene = Scene(host="arenaxr.org", realm="realm", scene="avatar")
+scene = Scene(host="arenaxr.org", scene="avatar")
 
 
 def user_join_callback(scene, camera, msg):

--- a/tools/dir-sign/dir-sign.py
+++ b/tools/dir-sign/dir-sign.py
@@ -18,7 +18,7 @@ title_text_font_width = 5
 link_text_font_width = 4
 
 
-scene = Scene(host="arenaxr.org",realm="realm",scene="example")
+scene = Scene(host="arenaxr.org",scene="example")
 
 print( "Starting up")
 

--- a/tools/etc-showcase/edit-room.py
+++ b/tools/etc-showcase/edit-room.py
@@ -3,7 +3,7 @@ import time
 import uuid
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", namespace="etc", scene="ProjectHub_2")
+scene = Scene(host="arenaxr.org", namespace="etc", scene="ProjectHub_2")
 
 def edit_scene_options():
     # create generic object for scene-options

--- a/tools/etc-showcase/etc-room.py
+++ b/tools/etc-showcase/etc-room.py
@@ -1,7 +1,7 @@
 from arena import *
 import time
 
-scene = Scene(host="arenaxr.org",realm="realm",scene="etc-room")
+scene = Scene(host="arenaxr.org",scene="etc-room")
 
 rot_state=0
 start_rot=0
@@ -37,7 +37,7 @@ def create_screenshare():
 # spings the TriBoard (also loaded here)
 @scene.run_once
 def get_sign():
-    global sign 
+    global sign
     global loaded
 
     # Get the sign model from persist / check that it exists
@@ -58,7 +58,7 @@ def get_sign():
         button.update_attributes(evt_handler=click_handler)
         button.update_attributes(clickable=True)
         scene.update_object(button)
-    
+
 # click_handler function that rotates sign when clicked
 # if not the "PushButton" object, it draws a laser ray
 def click_handler(scene,evt,msg):
@@ -68,7 +68,7 @@ def click_handler(scene,evt,msg):
     print("Got Click Event from:" + evt.object_id)
     if evt.type == "mousedown":
         if evt.object_id=="[PushButton]":
-            last_rot=rot_state        
+            last_rot=rot_state
             rot_state-=(360/3)%360
             # Set the baseline rotation before launching animation to avoid flicker
             sign.data.rotation.y=last_rot
@@ -87,7 +87,7 @@ def click_handler(scene,evt,msg):
             scene.add_object(line)
             ball = Sphere( position=end, scale = (0.06,0.06,0.06), color=(255,0,0), ttl=1)
             scene.add_object(ball)
-    
+
 
 # Load all clickable objects for laser
 # Note that objects made clickable while the program is running won't be added to this list

--- a/tools/etc-showcase/pinata.py
+++ b/tools/etc-showcase/pinata.py
@@ -8,18 +8,18 @@ from arena import *
 import random
 import time
 
-scene = Scene(host="arenaxr.org", realm="realm", scene="ProjectHub")
+scene = Scene(host="arenaxr.org", scene="ProjectHub")
 
 # Constants used to define operations
 RESPAWN_X_MIN = -67
 RESPAWN_X_MAX = 25
 RESPAWN_Z_MIN = -338
-RESPAWN_Z_MAX = -205 
+RESPAWN_Z_MAX = -205
 RESPAWN_Y = 20          # respawn at exactly this Y position
 HIT_RELOAD=10           # how many hits does it take
-#G_ACCEL = -9.8          
-#HIT_IMPULSE = 20        
-G_ACCEL = -19.8          
+#G_ACCEL = -9.8
+#HIT_IMPULSE = 20
+G_ACCEL = -19.8
 HIT_IMPULSE = 20        # Velocity added to hit
 GROUND_LEVEL = -1       # Ground level for pseudo-physics
 
@@ -40,7 +40,7 @@ APPLAUSE_SOUND_PATH="https://www.dropbox.com/s/3k9fin95z6nbex9/applause.wav?dl=0
 # location of the pinata
 pinata_loc = [0,0,0]
 pinata_state = IDLE  # 0-still, 1-moving, 2-explode, 3-waiting to restart
-hit_counter = HIT_RELOAD 
+hit_counter = HIT_RELOAD
 # time and velocity globals for physics
 t=0
 vy=0
@@ -55,13 +55,13 @@ def explode():
     scene.update_object(pinata)
     for i in range(50):
         rand_offset = (random.random()-0.5)/5
-        colorBox = Box(position=(pinata_loc[0]+rand_offset, pinata_loc[1]+rand_offset, pinata_loc[2]+rand_offset),scale=Scale(.5,.5,.5),ttl=15,physics=Physics(type="dynamic")) 
-        scene.add_object(colorBox) 
+        colorBox = Box(position=(pinata_loc[0]+rand_offset, pinata_loc[1]+rand_offset, pinata_loc[2]+rand_offset),scale=Scale(.5,.5,.5),ttl=15,physics=Physics(type="dynamic"))
+        scene.add_object(colorBox)
     explode_sound = Sound(src=EXPLODE_SOUND_PATH,positional=True,autoplay=True,poolSize=1 )
-    explode_sound_obj = Box(sound=explode_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10) 
+    explode_sound_obj = Box(sound=explode_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10)
     scene.add_object(explode_sound_obj)
     applause_sound = Sound(src=APPLAUSE_SOUND_PATH,positional=True,autoplay=True,poolSize=1 )
-    applause_sound_obj = Box(sound=applause_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10) 
+    applause_sound_obj = Box(sound=applause_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10)
     scene.add_object(applause_sound_obj)
 
 
@@ -87,7 +87,7 @@ def click(scene, evt, msg):
         scene.update_object(hit_text)
 
         hit_sound = Sound(src=HIT_SOUND_PATH,positional=True,autoplay=True,poolSize=10 )
-        hit_sound_obj = Box(sound=hit_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1) 
+        hit_sound_obj = Box(sound=hit_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1)
         scene.add_object(hit_sound_obj)
 
         print("Hit Counter: " + str(hit_counter))
@@ -99,10 +99,10 @@ def click(scene, evt, msg):
 def game_reset():
     global hit_counter,pinata_loc,pinata_state,pinata,hit_text,vy,t
     witch_sound = Sound(src=WITCH_SOUND_PATH,positional=True,autoplay=True,poolSize=1 )
-    witch_sound_obj = Box(sound=witch_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10) 
+    witch_sound_obj = Box(sound=witch_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=10)
     scene.add_object(witch_sound_obj)
     hit_counter=HIT_RELOAD
-    pinata_loc=[random.randrange(RESPAWN_X_MIN,RESPAWN_X_MAX),RESPAWN_Y,random.randrange(RESPAWN_Z_MIN,RESPAWN_Z_MAX)]   
+    pinata_loc=[random.randrange(RESPAWN_X_MIN,RESPAWN_X_MAX),RESPAWN_Y,random.randrange(RESPAWN_Z_MIN,RESPAWN_Z_MAX)]
     pinata.update_attributes(position=pinata_loc)
     scene.update_object(pinata)
     hit_text.update_attributes(text=str(hit_counter))
@@ -174,12 +174,12 @@ def main_loop():
         # Each time the pinata hits the ground, it bounces
         # This section converts some amount of velocity at impact to be rebounce
         # This section also caps small velocities to stop infinite bouncing
-        if y<=GROUND_LEVEL+.2:  
+        if y<=GROUND_LEVEL+.2:
             if vy>2 or  vy<-2:
                 vy=-.5*vy   # This is the bounce input, where the ground returns half the velocity
                 y = GROUND_LEVEL
                 boing_sound = Sound(src=BOUNCE_SOUND_PATH,positional=True,autoplay=True,poolSize=10 )
-                boing_sound_obj = Box(sound=boing_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1) 
+                boing_sound_obj = Box(sound=boing_sound,position=pinata_loc,scale=Scale(.01,.01,.01),ttl=1)
                 scene.add_object(boing_sound_obj)
             else:
                 # If the velocity is low enough, lets just cap it

--- a/tools/poster-session/image-switcher.py
+++ b/tools/poster-session/image-switcher.py
@@ -3,7 +3,7 @@ import os
 from google_drive_downloader import GoogleDriveDownloader as gdd
 
 # setup library
-scene = Scene(host="arenaxr.org", realm="realm", scene="test")
+scene = Scene(host="arenaxr.org", scene="test")
 
 @scene.run_async
 async def func():

--- a/tools/spin-poster/loader.py
+++ b/tools/spin-poster/loader.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org",realm="realm",scene="spin-poster")
+scene = Scene(host="arenaxr.org",scene="spin-poster")
 
 rot=0
 start_rot=0

--- a/tools/spin-poster/spin-poster.py
+++ b/tools/spin-poster/spin-poster.py
@@ -1,6 +1,6 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org",realm="realm",scene="spin-poster")
+scene = Scene(host="arenaxr.org",scene="spin-poster")
 
 rot=0
 start_rot=0
@@ -10,8 +10,8 @@ sign_z=-10
 
 @scene.run_once
 def make_sign():
-    global sign 
-    global button 
+    global sign
+    global button
     sign = GLTF(
         object_id="sign",
         position=(sign_x,sign_y,sign_z),
@@ -36,11 +36,11 @@ def make_sign():
     scene.add_object(button)
 
     slide1_material = Material(src="https://www.dropbox.com/s/3hccefrz6ywlknh/slide1.png?dl=0")
-    slide1 = Box( 
-        object_id="slide1", 
-        position=Position(0,3.21,0.57), 
-        rotation=(0,0,0), 
-        scale={"x":1.85,"y":3.35,"z":0}, 
+    slide1 = Box(
+        object_id="slide1",
+        position=Position(0,3.21,0.57),
+        rotation=(0,0,0),
+        scale={"x":1.85,"y":3.35,"z":0},
         material=slide1_material,
         persist=True,
         parent="sign"
@@ -49,11 +49,11 @@ def make_sign():
 
 
     slide2_material = Material(src="https://www.dropbox.com/s/xvh920h7zqeqaqd/slide2.png?dl=0")
-    slide2 = Box( 
-        object_id="slide2", 
-        position=Position(0.47,3.21,-.30), 
-        rotation=(0,120,0), 
-        scale={"x":1.85,"y":3.35,"z":0}, 
+    slide2 = Box(
+        object_id="slide2",
+        position=Position(0.47,3.21,-.30),
+        rotation=(0,120,0),
+        scale={"x":1.85,"y":3.35,"z":0},
         material=slide2_material,
         persist=True,
         parent="sign"
@@ -61,10 +61,10 @@ def make_sign():
     scene.add_object(slide2)
 
     slide3_material = Material(src="https://www.dropbox.com/s/krxk5n4kxetaxcd/slide3.png?dl=0")
-    slide3 = Box( object_id="slide3", 
+    slide3 = Box( object_id="slide3",
         position=Position(-0.50,3.21,-.30),
-        rotation=(0,-120,0), 
-        scale={"x":1.85,"y":3.35,"z":0}, 
+        rotation=(0,-120,0),
+        scale={"x":1.85,"y":3.35,"z":0},
         material=slide3_material,
         persist=True,
         parent="sign"
@@ -75,11 +75,11 @@ def make_sign():
 
 
 def click_handler(scene,evt,msg):
-    global rot    
+    global rot
     global sign # non allocated variables need to be global
 
     if evt.type == "mousedown":
-        last_rot=rot        
+        last_rot=rot
         rot-=(360/3)%360
         # Set the baseline rotation before launching animation to avoid flicker
         sign.data.rotation.y=last_rot

--- a/tools/spin-poster/spinner.py
+++ b/tools/spin-poster/spinner.py
@@ -1,7 +1,7 @@
 from arena import *
 import time
 
-scene = Scene(host="arenaxr.org",realm="realm",scene="spin-poster")
+scene = Scene(host="arenaxr.org",scene="spin-poster")
 
 rot_state=0
 start_rot=0
@@ -29,7 +29,7 @@ def get_sign():
         button.update_attributes(evt_handler=click_handler)
         button.update_attributes(clickable=True)
         scene.update_object(button)
-    
+
 # click_handler function that rotates sign when clicked
 def click_handler(scene,evt,msg):
     global sign # non allocated variables need to be global
@@ -37,7 +37,7 @@ def click_handler(scene,evt,msg):
 
     print("Got Click Event from:" + evt.object_id)
     if evt.type == "mousedown":
-        last_rot=rot_state        
+        last_rot=rot_state
         rot_state-=(360/3)%360
         # Set the baseline rotation before launching animation to avoid flicker
         sign.data.rotation.y=last_rot


### PR DESCRIPTION
- Remove param `realm` in examples to use default and avoid user confusion.
- Adds `Scene()` default `kwargs`: `realm = "realm"`
- Add `is param` check rather than `param is not None`, to allow checking for `None` as well as `""`.
- Add check that param `scene` does not include `"/"`.
- Order imports `scene.py`.
- Cleanup trailing whitespaces.
- Closes #92.