### PR TITLE
Add helper scripts

### DIFF
--- a/scripts/arena-show-permissions
+++ b/scripts/arena-show-permissions
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from arena import auth
+
+auth.permissions()

--- a/scripts/arena-sign-out
+++ b/scripts/arena-sign-out
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from arena import auth
+
+auth.signout()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/conix-center/ARENA-py",
     packages=setuptools.find_packages(),
+    scripts=[
+        'scripts/arena-sign-out',
+        'scripts/arena-show-permissions'
+    ],
     install_requires=[
         "aiohttp>=3.7.4",
         "paho-mqtt~=1.5.0",


### PR DESCRIPTION
This adds helper scripts for signing out and showing permissions. After installing `arena-py`, you can now run `arena-show-permissions` and `arena-sign-out`. 