### PR TITLE
Remove Objects when Receive Delete Message

### DIFF
--- a/arena/scene.py
+++ b/arena/scene.py
@@ -323,6 +323,7 @@ class Scene(object):
                                         )
                             elif self.delete_obj_callback:
                                 self.callback_wrapper(self.delete_obj_callback, obj, payload)
+                            Object.remove(obj)
                             continue
 
                         else: # create/update


### PR DESCRIPTION
Not yet tested. This ensures objects are removed locally when deleted remotely.