### PR TITLE
refactor: modular mqtt transport for mock testing

### DIFF
--- a/arena/scene.py
+++ b/arena/scene.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import traceback
 import uuid
-from datetime import datetime
+from datetime import datetime, UTC
 from inspect import signature
 from pathlib import Path
 
@@ -659,7 +659,7 @@ class Scene(ArenaMQTT):
                         {**self.topicParams, **{"objectId": obj['object_id'], "toUid": obj['_private_userid']}}
                     )
 
-            d = datetime.utcnow().isoformat()[:-3] + "Z"
+            d = datetime.now(UTC).isoformat()[:-3] + "Z"
 
             if custom_payload:
                 tmp_obj = obj

--- a/arena/scene.py
+++ b/arena/scene.py
@@ -675,7 +675,7 @@ class Scene(ArenaMQTT):
                     f"ERROR!! Publishing wire rotation data must be in Quaternion units, Euler conversion failed for payload: {payload}"
                 )
 
-            self.mqttc.publish(topic, payload, qos=0)
+            self.transport.publish(topic, payload, qos=0)
             if self.debug:
                 self.telemetry.add_event(f"[publish] {topic} {payload}")
             return payload

--- a/arena/test_system.py
+++ b/arena/test_system.py
@@ -63,8 +63,8 @@ class ArenaE2ETest:
         # Mock auth to avoid network calls
         os.environ["ARENA_USERNAME"] = "test_user"
         # minimal valid jwt structure: header.payload.signature
-        # {"exp": 1735689600, "publ": ["#"], "subl": ["#"]} base64 encoded
-        os.environ["ARENA_PASSWORD"] = "eyJhIjogMX0=.eyJleHAiOiAxNzM1Njg5NjAwLCAicHVibCI6IFsiIyJdLCAic3VibCI6IFsiIyJdfQ==.signature"
+        # {"exp": 1798675200, "publ": ["#"], "subl": ["#"]} base64 encoded (expires Dec 31, 2026)
+        os.environ["ARENA_PASSWORD"] = "eyJhIjogMX0=.eyJleHAiOiAxNzk4Njc1MjAwLCAicHVibCI6IFsiIyJdLCAic3VibCI6IFsiIyJdfQ==.signature"
 
         # Create mock transport
         self.transport = MockMQTTTransport("test_client")

--- a/arena/test_system.py
+++ b/arena/test_system.py
@@ -1,0 +1,180 @@
+import asyncio
+import json
+import os
+from unittest.mock import MagicMock
+from .scene import Scene
+from .transport import MockMQTTTransport
+
+class ArenaE2ETest:
+    def __init__(self, scene_name="test_scene", namespace="user", realm="realm"):
+        # Mock auth to avoid network calls
+        os.environ["ARENA_USERNAME"] = "test_user"
+        # minimal valid jwt structure: header.payload.signature
+        # {"exp": 1735689600, "publ": ["#"], "subl": ["#"]} base64 encoded
+        os.environ["ARENA_PASSWORD"] = "eyJhIjogMX0=.eyJleHAiOiAxNzM1Njg5NjAwLCAicHVibCI6IFsiIyJdLCAic3VibCI6IFsiIyJdfQ==.signature"
+
+        # Create mock transport
+        self.transport = MockMQTTTransport("test_client")
+        self.scene_name = scene_name
+        
+        # Instantiate scene with mock transport; process headless to avoid user auth interactions
+        self.scene = Scene(
+            host="example.com",
+            realm=realm,
+            namespace=namespace,
+            scene=scene_name,
+            transport=self.transport,
+            headless=True,
+            config_data={
+                "ARENADefaults": {
+                    "mqttHost": "mqtt.example.com",
+                    "latencyTopic": "$NETWORK/latency",
+                    "persistHost": "persist.example.com",
+                    "persistPath": "/persist/",
+                    "realm": "realm",
+                    "namespace": "public",
+                    "sceneName": "lobby",
+                    "graphTopic": "$NETWORK",
+                    "camUpdateIntervalMs": 100,
+                    "userName": "Anonymous",
+                    "startCoords": {"x": 0, "y": 0, "z": 0},
+                    "camHeight": 1.6,
+                    "vioTopic": "/topic/vio/",
+                    "headModelPath": "/static/models/avatars/robobit.glb"
+                }
+            } 
+        )
+
+        # Mock auth.urlopen to return persist data
+        # Data provided by user example
+        persist_data = [
+            {"object_id": "lobby-model", "attributes": {"object_type": "gltf-model", "position": {"x": 0, "y": -2, "z": 0}}, "type": "object"},
+            {"object_id": "start", "attributes": {"object_type": "cube", "position": {"x": 18, "y": -2, "z": 11.5}}, "type": "object"}
+        ]
+        self.scene.auth.urlopen = MagicMock(return_value=json.dumps(persist_data))
+        
+        # Start tasks manually since we won't call run_forever
+        self._start_tasks()
+        
+    def _start_tasks(self):
+        """Manually start the background tasks of the scene."""
+        current_loop = asyncio.get_event_loop()
+        # Verify if scene loop is same as current loop
+        if self.scene.event_loop.loop is not current_loop:
+            pass
+            
+        for task in self.scene.event_loop.tasks:
+             asyncio.create_task(task)
+
+    def inject_message(self, topic, payload):
+        """Injects a message as if received from MQTT."""
+        # payload is a dict, we convert to bytes for mock transport
+        payload_bytes = json.dumps(payload).encode('utf-8')
+        self.transport.mock_receive(topic, payload_bytes)
+        
+    async def run_step(self, duration=0.1):
+        """Runs the event loop for a short duration."""
+        await asyncio.sleep(duration)
+        
+    def capture_published_messages(self):
+        """Returns list of published messages."""
+        return self.transport.published_messages
+
+    async def verify_trace(self, trace_path : str):
+        """
+        Verifies execution against a recorded trace.
+        - 'output' events in trace are expected to be published by the scene.
+        - 'input' events in trace are injected into the scene.
+        """
+        import json
+        with open(trace_path, 'r') as f:
+            events = json.load(f)
+            
+        print(f"[Verify] Loaded {len(events)} events from {trace_path}")
+        
+        # Cursor for our captured messages
+        captured_idx = 0
+        
+        for i, event in enumerate(events):
+            if event['type'] == 'input':
+                print(f"[Verify] Step {i}: Injecting input {event['topic']}")
+                
+                # Ensure subscriptions are active before injecting first message
+                if i == 0 or not self.transport.subscriptions:
+                    pass # Wait for subscriptions check (simplified logic)
+                    for _ in range(5): 
+                        if self.transport.subscriptions: break
+                        await self.run_step(0.1)
+
+                self.inject_message(event['topic'], event['payload'])
+                # Give time for processing
+                await self.run_step(0.1)
+                
+            elif event['type'] == 'output':
+                print(f"[Verify] Step {i}: Expecting output {event['topic']}")
+                
+                # We need to find this message in our captured list.
+                # We search from captured_idx onwards.
+                # We might need to wait if it hasn't arrived yet.
+                found = False
+                attempts = 0
+                max_attempts = 20 # 2 seconds
+                
+                while not found and attempts < max_attempts:
+                    current_msgs = self.transport.published_messages
+                    
+                    # Search new messages
+                    for idx in range(captured_idx, len(current_msgs)):
+                        msg = current_msgs[idx]
+                        
+                        # Match logic: Topic must match. Payload must match subset.
+                        # Trace payload might be partial or full.
+                        # For simple verification, let's match action and object_id if present.
+                        
+                        trace_payload = event['payload']
+                        actual_payload = msg['payload']
+                        if isinstance(actual_payload, bytes): actual_payload = actual_payload.decode('utf-8')
+                        if isinstance(actual_payload, str):
+                            try: actual_payload = json.loads(actual_payload)
+                            except: pass
+
+                        # Relaxed Topic Match:
+                        # Topics often contain session-specific IDs (e.g. .../o/Ivan_34823_py/object).
+                        # We match if:
+                        # 1. Exact topic match.
+                        # 2. Suffix match on '/{object_id}' (if object_id is known).
+                        topic_match = (msg['topic'] == event['topic'])
+                        if not topic_match and 'object_id' in trace_payload:
+                             obj_id = trace_payload['object_id']
+                             if msg['topic'].endswith(f"/{obj_id}") and event['topic'].endswith(f"/{obj_id}"):
+                                 topic_match = True
+                        
+                        if not topic_match: continue
+
+                        # Payload Verification: Check critical keys (action, object_id, type)
+                        match = True
+                        if isinstance(trace_payload, dict) and isinstance(actual_payload, dict):
+                            for key in ['action', 'object_id', 'type']:
+                                if key in trace_payload:
+                                    if trace_payload[key] != actual_payload.get(key):
+                                        match = False
+                                        break
+                            # Also check 'data' subset if present?
+                            if match and 'data' in trace_payload and 'data' in actual_payload:
+                                # Start simplified: if trace has object_type, match it
+                                if 'object_type' in trace_payload['data']:
+                                    if trace_payload['data']['object_type'] != actual_payload['data'].get('object_type'):
+                                        match = False
+                        
+                        if match:
+                            found = True
+                            captured_idx = idx + 1 # Advance cursor
+                            print(f"[Verify]   Matched message index {idx}")
+                            break
+                    
+                    if not found:
+                        await self.run_step(0.1)
+                        attempts += 1
+                        
+                if not found:
+                    raise AssertionError(f"Step {i} Failed: Expected output {event['topic']} with payload {event['payload']} not found within timeout.")

--- a/arena/test_system.py
+++ b/arena/test_system.py
@@ -9,7 +9,7 @@ from .transport import MockMQTTTransport
 from .objects import Object
 
 # Fields to ignore when comparing payloads (dynamic/timing-related)
-IGNORE_FIELDS = {'timestamp', 'time', 'ts', 'lastUpdated', 'createdAt', 'updatedAt'}
+IGNORE_FIELDS = {"timestamp", "time", "ts", "lastUpdated", "createdAt", "updatedAt"}
 
 
 def payloads_match(expected, actual, path=""):
@@ -19,16 +19,20 @@ def payloads_match(expected, actual, path=""):
     """
     # Normalize: if either is bytes, decode
     if isinstance(expected, bytes):
-        expected = json.loads(expected.decode('utf-8'))
+        expected = json.loads(expected.decode("utf-8"))
     if isinstance(actual, bytes):
-        actual = json.loads(actual.decode('utf-8'))
+        actual = json.loads(actual.decode("utf-8"))
     if isinstance(expected, str):
-        try: expected = json.loads(expected)
-        except json.JSONDecodeError: pass
+        try:
+            expected = json.loads(expected)
+        except json.JSONDecodeError:
+            pass
     if isinstance(actual, str):
-        try: actual = json.loads(actual)
-        except json.JSONDecodeError: pass
-    
+        try:
+            actual = json.loads(actual)
+        except json.JSONDecodeError:
+            pass
+
     # If both are dicts, compare keys
     if isinstance(expected, dict) and isinstance(actual, dict):
         for key in expected:
@@ -40,21 +44,24 @@ def payloads_match(expected, actual, path=""):
             if not match:
                 return False, diff
         return True, None
-    
+
     # If both are lists, compare element-wise
     if isinstance(expected, list) and isinstance(actual, list):
         if len(expected) != len(actual):
-            return False, f"{path}: list length mismatch ({len(expected)} vs {len(actual)})"
+            return (
+                False,
+                f"{path}: list length mismatch ({len(expected)} vs {len(actual)})",
+            )
         for i, (e, a) in enumerate(zip(expected, actual)):
             match, diff = payloads_match(e, a, f"{path}[{i}]")
             if not match:
                 return False, diff
         return True, None
-    
+
     # Direct comparison for primitives
     if expected != actual:
         return False, f"{path}: {expected!r} != {actual!r}"
-    
+
     return True, None
 
 
@@ -64,12 +71,14 @@ class ArenaE2ETest:
         os.environ["ARENA_USERNAME"] = "test_user"
         # minimal valid jwt structure: header.payload.signature
         # {"exp": 1798675200, "publ": ["#"], "subl": ["#"]} base64 encoded (expires Dec 31, 2026)
-        os.environ["ARENA_PASSWORD"] = "eyJhIjogMX0=.eyJleHAiOiAxNzk4Njc1MjAwLCAicHVibCI6IFsiIyJdLCAic3VibCI6IFsiIyJdfQ==.signature"
+        os.environ["ARENA_PASSWORD"] = (
+            "eyJhIjogMX0=.eyJleHAiOiAxNzk4Njc1MjAwLCAicHVibCI6IFsiIyJdLCAic3VibCI6IFsiIyJdfQ==.signature"
+        )
 
         # Create mock transport
         self.transport = MockMQTTTransport("test_client")
         self.scene_name = scene_name
-        
+
         # Instantiate scene with mock transport; process headless to avoid user auth interactions
         self.scene = Scene(
             host="example.com",
@@ -93,54 +102,70 @@ class ArenaE2ETest:
                     "startCoords": {"x": 0, "y": 0, "z": 0},
                     "camHeight": 1.6,
                     "vioTopic": "/topic/vio/",
-                    "headModelPath": "/static/models/avatars/robobit.glb"
+                    "headModelPath": "/static/models/avatars/robobit.glb",
                 }
-            } 
+            },
         )
 
         # Mock auth.urlopen to return persist data
         # Data provided by user example
         persist_data = [
-            {"object_id": "lobby-model", "attributes": {"object_type": "gltf-model", "position": {"x": 0, "y": -2, "z": 0}}, "type": "object"},
-            {"object_id": "start", "attributes": {"object_type": "box", "position": {"x": 18, "y": -2, "z": 11.5}}, "type": "object"}
+            {
+                "object_id": "lobby-model",
+                "attributes": {
+                    "object_type": "gltf-model",
+                    "position": {"x": 0, "y": -2, "z": 0},
+                },
+                "type": "object",
+            },
+            {
+                "object_id": "start",
+                "attributes": {
+                    "object_type": "box",
+                    "position": {"x": 18, "y": -2, "z": 11.5},
+                },
+                "type": "object",
+            },
         ]
         self.scene.auth.urlopen = MagicMock(return_value=json.dumps(persist_data))
-        
+
         # Tasks will be started when entering async context
         self._tasks_started = False
-        
+
     def _start_tasks(self):
         """Start background tasks of the scene. Must be called from async context."""
         if self._tasks_started:
             return
         self._tasks_started = True
-        
+
         for task in self.scene.event_loop.tasks:
             asyncio.create_task(task)
 
     def inject_message(self, topic, payload):
         """Injects a message as if received from MQTT."""
         # payload is a dict, we convert to bytes for mock transport
-        payload_bytes = json.dumps(payload).encode('utf-8')
+        payload_bytes = json.dumps(payload).encode("utf-8")
         self.transport.mock_receive(topic, payload_bytes)
-        
+
     async def run_step(self, duration=0.1):
         """Runs the event loop for a short duration."""
         await asyncio.sleep(duration)
-        
+
     def capture_published_messages(self):
         """Returns list of published messages."""
         return self.transport.published_messages
 
-    async def verify_trace(self, trace_path: str, on_output_match=None, on_any_output=None):
+    async def verify_trace(
+        self, trace_path: str, on_output_match=None, on_any_output=None
+    ):
         """
         Verifies execution against a recorded trace.
-        
+
         Args:
             trace_path: Path to the trace JSON file
             on_output_match: Callback(event_idx, expected, actual) called when an output matches
             on_any_output: Callback(actual) called for every captured output
-        
+
         Sequencing:
         - 'output' events are batched until the next 'input' or end of trace
         - All expected outputs in a batch are verified before injecting the next input
@@ -148,26 +173,26 @@ class ArenaE2ETest:
         """
         # Start background tasks now that we're in async context
         self._start_tasks()
-        
-        with open(trace_path, 'r') as f:
+
+        with open(trace_path, "r") as f:
             events = json.load(f)
-            
+
         print(f"[Verify] Loaded {len(events)} events from {trace_path}")
-        
+
         # Group events into batches: each batch is (optional input, [outputs])
         # This allows us to verify all outputs triggered by an input before moving on
         batches = []
         current_outputs = []
-        
+
         for event in events:
-            if event['type'] == 'input':
+            if event["type"] == "input":
                 # If we have pending outputs, they belong to the previous batch (or initial state)
                 if current_outputs:
                     batches.append((None, current_outputs))
                     current_outputs = []
                 # Start a new batch with this input
                 batches.append((event, []))
-            elif event['type'] == 'output':
+            elif event["type"] == "output":
                 # Add to current batch's outputs
                 if batches and batches[-1][0] is not None:
                     # Append to the last input's outputs
@@ -175,44 +200,66 @@ class ArenaE2ETest:
                 else:
                     # Output before any input (initial outputs)
                     current_outputs.append(event)
-        
+
         # Don't forget trailing outputs
         if current_outputs:
             batches.append((None, current_outputs))
-        
+
         # Track which captured messages we've already matched
         matched_indices = set()
-        
+
         for batch_idx, (input_event, expected_outputs) in enumerate(batches):
             if input_event is None:
                 # Initial outputs - verify them first (no input to trigger)
                 if expected_outputs:
-                    print(f"[Verify] Batch {batch_idx}: Expecting {len(expected_outputs)} initial output(s)")
-                    await self._verify_outputs(expected_outputs, matched_indices, on_output_match, on_any_output)
+                    print(
+                        f"[Verify] Batch {batch_idx}: Expecting {len(expected_outputs)} initial output(s)"
+                    )
+                    await self._verify_outputs(
+                        expected_outputs,
+                        matched_indices,
+                        on_output_match,
+                        on_any_output,
+                    )
             else:
                 # Input batch: inject input FIRST, then verify outputs it triggers
-                print(f"[Verify] Batch {batch_idx}: Injecting input {input_event['topic']}")
-                
+                print(
+                    f"[Verify] Batch {batch_idx}: Injecting input {input_event['topic']}"
+                )
+
                 # Ensure subscriptions are active before first injection
                 if not self.transport.subscriptions:
                     for _ in range(5):
-                        if self.transport.subscriptions: break
+                        if self.transport.subscriptions:
+                            break
                         await self.run_step(0.1)
-                
-                self.inject_message(input_event['topic'], input_event['payload'])
+
+                self.inject_message(input_event["topic"], input_event["payload"])
                 await self.run_step(0.1)
-                
+
                 # Now verify the outputs triggered by this input
                 if expected_outputs:
-                    print(f"[Verify] Batch {batch_idx}: Expecting {len(expected_outputs)} output(s)")
-                    await self._verify_outputs(expected_outputs, matched_indices, on_output_match, on_any_output)
-        
+                    print(
+                        f"[Verify] Batch {batch_idx}: Expecting {len(expected_outputs)} output(s)"
+                    )
+                    await self._verify_outputs(
+                        expected_outputs,
+                        matched_indices,
+                        on_output_match,
+                        on_any_output,
+                    )
+
         print("[Verify] Trace verification complete - all outputs matched.")
 
-    async def _verify_outputs(self, expected_outputs: list, matched_indices: set, 
-                              on_output_match=None, on_any_output=None):
+    async def _verify_outputs(
+        self,
+        expected_outputs: list,
+        matched_indices: set,
+        on_output_match=None,
+        on_any_output=None,
+    ):
         """Verify a batch of expected outputs, waiting for them to appear.
-        
+
         Args:
             expected_outputs: List of expected output events from trace
             matched_indices: Set of already-matched message indices
@@ -220,58 +267,62 @@ class ArenaE2ETest:
             on_any_output: Callback(actual) for each captured output
         """
         for i, event in enumerate(expected_outputs):
-            expected_payload = event['payload']
+            expected_payload = event["payload"]
             found = False
             attempts = 0
             max_attempts = 20  # 2 seconds total
             best_diff = None
-            
+
             while not found and attempts < max_attempts:
                 current_msgs = self.transport.published_messages
-                
+
                 for idx in range(len(current_msgs)):
                     if idx in matched_indices:
                         continue
-                    
+
                     msg = current_msgs[idx]
-                    actual_payload = msg['payload']
-                    
+                    actual_payload = msg["payload"]
+
                     # Ensure actual_payload is parsed (may be JSON string)
                     if isinstance(actual_payload, str):
                         try:
                             actual_payload = json.loads(actual_payload)
                         except json.JSONDecodeError:
                             pass  # Keep as string if not valid JSON
-                    
+
                     # Call on_any_output for every output we see (first time)
                     if on_any_output and idx not in matched_indices:
                         try:
                             on_any_output(actual_payload)
                         except Exception as e:
-                            raise AssertionError(f"on_any_output callback failed for message {idx}: {e}")
-                    
+                            raise AssertionError(
+                                f"on_any_output callback failed for message {idx}: {e}"
+                            )
+
                     match, diff = payloads_match(expected_payload, actual_payload)
-                    
+
                     if match:
                         found = True
                         matched_indices.add(idx)
                         print(f"[Verify]   ✓ Output {i}: Matched message [{idx}]")
-                        
+
                         # Call on_output_match callback
                         if on_output_match:
                             try:
                                 on_output_match(i, expected_payload, actual_payload)
                             except Exception as e:
-                                raise AssertionError(f"on_output_match callback failed for output {i}: {e}")
+                                raise AssertionError(
+                                    f"on_output_match callback failed for output {i}: {e}"
+                                )
                         break
                     else:
                         if best_diff is None:
                             best_diff = diff
-                
+
                 if not found:
                     await self.run_step(0.1)
                     attempts += 1
-            
+
             if not found:
                 raise AssertionError(
                     f"Output verification failed for: {event['topic']}\n"
@@ -281,29 +332,35 @@ class ArenaE2ETest:
                 )
 
     @classmethod
-    def run_script(cls, script_path: str, trace_path: str, 
-                   on_output_match=None, on_any_output=None, **scene_kwargs) -> bool:
+    def run_script(
+        cls,
+        script_path: str,
+        trace_path: str,
+        on_output_match=None,
+        on_any_output=None,
+        **scene_kwargs,
+    ) -> bool:
         """
         Load and test an existing script against a recorded trace.
-        
+
         Args:
             script_path: Path to the Python script (e.g., 'examples/random_sphere.py')
             trace_path: Path to the recorded trace JSON file
             on_output_match: Callback(event_idx, expected, actual) called when output matches
             on_any_output: Callback(actual) called for every captured output
             **scene_kwargs: Override scene parameters (scene_name, namespace, realm)
-        
+
         Returns:
             True if verification passed, raises AssertionError otherwise
-        
+
         Usage:
             ArenaE2ETest.run_script('examples/random_sphere.py', 'traces/random_sphere.json')
         """
         # Extract scene params from trace or use defaults
-        scene_name = scene_kwargs.get('scene_name', 'test_scene')
-        namespace = scene_kwargs.get('namespace', 'public')
-        realm = scene_kwargs.get('realm', 'realm')
-        
+        scene_name = scene_kwargs.get("scene_name", "test_scene")
+        namespace = scene_kwargs.get("namespace", "public")
+        realm = scene_kwargs.get("realm", "realm")
+
         # Ensure a fresh event loop exists (asyncio.run closes the loop after each call)
         try:
             loop = asyncio.get_running_loop()
@@ -311,67 +368,70 @@ class ArenaE2ETest:
             # No running loop - create a new one
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        
+
         # Clear global object registry for clean state
         Object.all_objects = {}
         Object.private_objects = {}
-        
+
         # Create harness with mock transport
         harness = cls(scene_name=scene_name, namespace=namespace, realm=realm)
-        
+
         # Make run_tasks() a no-op so script doesn't block
         original_run_tasks = harness.scene.run_tasks
         harness.scene.run_tasks = lambda: None
-        
+
         # Add script's directory to path so relative imports work
         script_dir = os.path.dirname(os.path.abspath(script_path))
         if script_dir not in sys.path:
             sys.path.insert(0, script_dir)
-        
+
         try:
             # Create a Scene factory that returns our harness scene
             def mock_scene_factory(*args, **kwargs):
                 return harness.scene
-            
+
             # Build a namespace with all arena exports, plus our mock Scene
             import arena
             import arena.objects
             import arena.attributes
+
             script_globals = {}
-            
+
             # Copy all arena exports (including submodule exports)
             for mod in [arena, arena.objects, arena.attributes]:
                 for name in dir(mod):
-                    if not name.startswith('_'):
+                    if not name.startswith("_"):
                         script_globals[name] = getattr(mod, name)
-            
+
             # Override Scene with our mock
-            script_globals['Scene'] = mock_scene_factory
-            
+            script_globals["Scene"] = mock_scene_factory
+
             # Add builtins
-            script_globals['__builtins__'] = __builtins__
-            script_globals['__name__'] = '__main__'
-            script_globals['__file__'] = script_path
-            
+            script_globals["__builtins__"] = __builtins__
+            script_globals["__name__"] = "__main__"
+            script_globals["__file__"] = script_path
+
             try:
                 # Load and execute the script with our prepared namespace
                 print(f"[Test] Loading script: {script_path}")
-                with open(script_path, 'r') as f:
+                with open(script_path, "r") as f:
                     script_code = f.read()
-                
-                exec(compile(script_code, script_path, 'exec'), script_globals)
-                print(f"[Test] Script loaded. Objects created: {len(Object.all_objects)}")
+
+                exec(compile(script_code, script_path, "exec"), script_globals)
+                print(
+                    f"[Test] Script loaded. Objects created: {len(Object.all_objects)}"
+                )
             except SystemExit:
                 pass  # Script may call sys.exit() or similar
-            
+
             # Now verify against trace
             async def _verify():
                 await harness.verify_trace(trace_path, on_output_match, on_any_output)
-            
+
             asyncio.run(_verify())
             print(f"[Test] ✓ {script_path} passed verification")
             return True
-            
+
         finally:
             # Restore run_tasks
             harness.scene.run_tasks = original_run_tasks
@@ -383,40 +443,46 @@ class ArenaE2ETest:
     def run_test_suite(cls, test_cases: list) -> dict:
         """
         Run multiple script tests and report results.
-        
+
         Args:
             test_cases: List of dicts with 'script', 'trace', and optional scene kwargs
                 Example: [
                     {'script': 'examples/random_sphere.py', 'trace': 'traces/random_sphere.json'},
                     {'script': 'examples/box_click.py', 'trace': 'traces/box_click.json', 'scene_name': 'click'},
                 ]
-        
+
         Returns:
             Dict with 'passed', 'failed', and 'results' keys
         """
-        results = {'passed': 0, 'failed': 0, 'results': []}
-        
+        results = {"passed": 0, "failed": 0, "results": []}
+
         for i, test_case in enumerate(test_cases):
-            script = test_case['script']
-            trace = test_case['trace']
-            kwargs = {k: v for k, v in test_case.items() if k not in ('script', 'trace')}
-            
-            print(f"\n{'='*60}")
-            print(f"[Suite] Test {i+1}/{len(test_cases)}: {script}")
-            print('='*60)
-            
+            script = test_case["script"]
+            trace = test_case["trace"]
+            kwargs = {
+                k: v for k, v in test_case.items() if k not in ("script", "trace")
+            }
+
+            print(f"\n{'=' * 60}")
+            print(f"[Suite] Test {i + 1}/{len(test_cases)}: {script}")
+            print("=" * 60)
+
             try:
                 cls.run_script(script, trace, **kwargs)
-                results['passed'] += 1
-                results['results'].append({'script': script, 'status': 'PASSED'})
+                results["passed"] += 1
+                results["results"].append({"script": script, "status": "PASSED"})
             except Exception as e:
-                results['failed'] += 1
-                results['results'].append({'script': script, 'status': 'FAILED', 'error': str(e)})
+                results["failed"] += 1
+                results["results"].append(
+                    {"script": script, "status": "FAILED", "error": str(e)}
+                )
                 print(f"[Suite] ✗ {script} FAILED: {e}")
-        
+
         # Summary
-        print(f"\n{'='*60}")
-        print(f"[Suite] Results: {results['passed']} passed, {results['failed']} failed")
-        print('='*60)
-        
+        print(f"\n{'=' * 60}")
+        print(
+            f"[Suite] Results: {results['passed']} passed, {results['failed']} failed"
+        )
+        print("=" * 60)
+
         return results

--- a/arena/transport.py
+++ b/arena/transport.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 import asyncio
-import socket
 import paho.mqtt.client as mqtt
 from paho.mqtt.client import topic_matches_sub
 from .event_loop.asyncio_mqtt import AsyncioMQTTHelper
@@ -199,7 +198,7 @@ class MockMQTTTransport(Transport):
         return None 
 
     def subscribe(self, topic):
-        # mid=random
+        # mid=1 (fixed for mock)
         mid = 1
         self.subscriptions[topic] = None # No specific callback added yet via add, just general sub
         return (0, mid) # (result, mid)

--- a/arena/transport.py
+++ b/arena/transport.py
@@ -6,10 +6,12 @@ from .event_loop.asyncio_mqtt import AsyncioMQTTHelper
 import json
 import time
 
+
 class Transport(ABC):
     """
     Abstract base class for MQTT Transport.
     """
+
     def __init__(self):
         self.on_connect = None
         self.on_disconnect = None
@@ -32,7 +34,7 @@ class Transport(ABC):
     @abstractmethod
     def subscribe(self, topic):
         pass
-    
+
     @abstractmethod
     def unsubscribe(self, topic):
         pass
@@ -46,23 +48,31 @@ class Transport(ABC):
     def loop_stop(self):
         """Stops the event loop integration."""
         pass
-        
+
     @abstractmethod
     def username_pw_set(self, username, password=None):
         pass
 
     @abstractmethod
-    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None):
+    def tls_set(
+        self,
+        ca_certs=None,
+        certfile=None,
+        keyfile=None,
+        cert_reqs=None,
+        tls_version=None,
+        ciphers=None,
+    ):
         pass
 
     @abstractmethod
     def tls_set_context(self, context=None):
         pass
-        
+
     @abstractmethod
     def tls_insecure_set(self, value):
         pass
-    
+
     @abstractmethod
     def message_callback_add(self, sub, callback):
         pass
@@ -70,24 +80,26 @@ class Transport(ABC):
     @abstractmethod
     def message_callback_remove(self, sub):
         pass
-    
+
     @abstractmethod
     def socket(self):
         pass
-        
+
     @property
     @abstractmethod
     def _out_packet(self):
-         pass
+        pass
+
 
 class PahoMQTTTransport(Transport):
     """
     Transport implementation using Paho MQTT Client.
     """
+
     def __init__(self, client_id, clean_session=True):
         super().__init__()
         self.mqttc = mqtt.Client(
-             mqtt.CallbackAPIVersion.VERSION2, client_id, clean_session=clean_session
+            mqtt.CallbackAPIVersion.VERSION2, client_id, clean_session=clean_session
         )
         self.aioh = None
 
@@ -105,15 +117,15 @@ class PahoMQTTTransport(Transport):
     def _on_disconnect_wrapper(self, client, userdata, rc, properties):
         if self.on_disconnect:
             self.on_disconnect(client, userdata, rc, properties)
-            
+
     def _on_publish_wrapper(self, client, userdata, mid, rc, properties):
         if self.on_publish:
             self.on_publish(client, userdata, mid, rc, properties)
-            
+
     def _on_subscribe_wrapper(self, client, userdata, mid, rc_list, properties):
         if self.on_subscribe:
             self.on_subscribe(client, userdata, mid, rc_list, properties)
-            
+
     def _on_message_wrapper(self, client, userdata, msg):
         if self.on_message:
             self.on_message(client, userdata, msg)
@@ -129,7 +141,7 @@ class PahoMQTTTransport(Transport):
 
     def subscribe(self, topic):
         return self.mqttc.subscribe(topic)
-    
+
     def unsubscribe(self, topic):
         return self.mqttc.unsubscribe(topic)
 
@@ -137,54 +149,63 @@ class PahoMQTTTransport(Transport):
         self.aioh = AsyncioMQTTHelper(event_loop, self.mqttc)
 
     def loop_stop(self):
-        # AsyncioMQTTHelper doesn't seem to have a clear stop/cleanup method exposed 
+        # AsyncioMQTTHelper doesn't seem to have a clear stop/cleanup method exposed
         # but the event loop controls it.
         pass
 
     def username_pw_set(self, username, password=None):
         self.mqttc.username_pw_set(username, password)
 
-    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None):
+    def tls_set(
+        self,
+        ca_certs=None,
+        certfile=None,
+        keyfile=None,
+        cert_reqs=None,
+        tls_version=None,
+        ciphers=None,
+    ):
         self.mqttc.tls_set(ca_certs, certfile, keyfile, cert_reqs, tls_version, ciphers)
 
     def tls_set_context(self, context=None):
         self.mqttc.tls_set_context(context)
-        
+
     def tls_insecure_set(self, value):
         self.mqttc.tls_insecure_set(value)
 
     def message_callback_add(self, sub, callback):
         self.mqttc.message_callback_add(sub, callback)
-    
+
     def message_callback_remove(self, sub):
         self.mqttc.message_callback_remove(sub)
-        
+
     def socket(self):
         return self.mqttc.socket()
-        
+
     @property
     def _out_packet(self):
         return self.mqttc._out_packet
+
 
 class MockMQTTTransport(Transport):
     """
     Mock Transport for testing.
     """
+
     def __init__(self, client_id, clean_session=True):
         super().__init__()
         self.client_id = client_id
         self.connected = False
-        self.subscriptions = {} # topic -> callback
+        self.subscriptions = {}  # topic -> callback
         self.published_messages = []
         self._out_packet_mock = 0
 
     def connect(self, host, port=1883, keepalive=60):
         self.connected = True
         # If event loop is already started, schedule the connection callback
-        if hasattr(self, 'event_loop') and self.event_loop:
-             self._schedule_connect()
+        if hasattr(self, "event_loop") and self.event_loop:
+            self._schedule_connect()
         return 0
-    
 
     def disconnect(self):
         self.connected = False
@@ -192,16 +213,18 @@ class MockMQTTTransport(Transport):
             self.on_disconnect(self, None, 0, None)
 
     def publish(self, topic, payload, qos=0):
-        self.published_messages.append({'topic': topic, 'payload': payload, 'qos': qos})
+        self.published_messages.append({"topic": topic, "payload": payload, "qos": qos})
         if self.on_publish:
             self.on_publish(self, None, 1, 0, None)
-        return None 
+        return None
 
     def subscribe(self, topic):
         # mid=1 (fixed for mock)
         mid = 1
-        self.subscriptions[topic] = None # No specific callback added yet via add, just general sub
-        return (0, mid) # (result, mid)
+        self.subscriptions[topic] = (
+            None  # No specific callback added yet via add, just general sub
+        )
+        return (0, mid)  # (result, mid)
 
     def unsubscribe(self, topic):
         if topic in self.subscriptions:
@@ -212,7 +235,7 @@ class MockMQTTTransport(Transport):
         self.loop_start_called = True
         self.event_loop = event_loop
         if self.connected:
-             self._schedule_connect()
+            self._schedule_connect()
 
     def _schedule_connect(self):
         # We need to trigger on_connect on the loop
@@ -220,9 +243,10 @@ class MockMQTTTransport(Transport):
             await asyncio.sleep(0.01)
             if self.on_connect:
                 self.on_connect(self, None, {}, 0, None)
-        
+
         # We can add a task to the event_loop wrapper
         from .event_loop import AsyncWorker
+
         w = AsyncWorker(self.event_loop, _trigger, None)
         self.event_loop.add_task(w)
 
@@ -232,7 +256,15 @@ class MockMQTTTransport(Transport):
     def username_pw_set(self, username, password=None):
         pass
 
-    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None):
+    def tls_set(
+        self,
+        ca_certs=None,
+        certfile=None,
+        keyfile=None,
+        cert_reqs=None,
+        tls_version=None,
+        ciphers=None,
+    ):
         pass
 
     def tls_set_context(self, context=None):
@@ -240,26 +272,29 @@ class MockMQTTTransport(Transport):
 
     def tls_insecure_set(self, value):
         pass
-        
+
     def message_callback_add(self, sub, callback):
         # Store callback for this subscription
         self.subscriptions[sub] = callback
-        
+
     def message_callback_remove(self, sub):
         if sub in self.subscriptions:
             del self.subscriptions[sub]
 
     def socket(self):
         class MockSocket:
-            def setsockopt(self, *args, **kwargs): pass
+            def setsockopt(self, *args, **kwargs):
+                pass
+
         return MockSocket()
-        
+
     @property
     def _out_packet(self):
         return self._out_packet_mock
 
     def mock_receive(self, topic, payload):
         """Simulate receiving a message."""
+
         # Simple mock message object
         class MockMsg:
             def __init__(self, t, p):
@@ -267,9 +302,9 @@ class MockMQTTTransport(Transport):
                 self.payload = p
                 self.qos = 0
                 self.retain = False
-        
+
         msg = MockMsg(topic, payload)
-        
+
         # Find matching subscription
         matched = False
         for sub, callback in self.subscriptions.items():
@@ -277,20 +312,22 @@ class MockMQTTTransport(Transport):
                 if callback:
                     callback(self, None, msg)
                     matched = True
-        
+
         if not matched and self.on_message:
             self.on_message(self, None, msg)
+
 
 class RecorderTransport(Transport):
     """
     Wraps another Transport to record input/output messages.
     """
+
     def __init__(self, inner_transport, trace_file="mqtt_trace.json"):
         super().__init__()
         self.inner = inner_transport
         self.trace_file = trace_file
         self.events = []
-        
+
         # Proxy properties
         self.inner.on_connect = self._on_connect_wrapper
         self.inner.on_disconnect = self._on_disconnect_wrapper
@@ -299,34 +336,43 @@ class RecorderTransport(Transport):
         self.inner.on_message = self._on_message_wrapper
 
     def _on_connect_wrapper(self, client, userdata, flags, rc, properties):
-        if self.on_connect: self.on_connect(client, userdata, flags, rc, properties)
+        if self.on_connect:
+            self.on_connect(client, userdata, flags, rc, properties)
 
     def _on_disconnect_wrapper(self, client, userdata, rc, properties):
-        if self.on_disconnect: self.on_disconnect(client, userdata, rc, properties)
-            
+        if self.on_disconnect:
+            self.on_disconnect(client, userdata, rc, properties)
+
     def _on_publish_wrapper(self, client, userdata, mid, rc, properties):
-        if self.on_publish: self.on_publish(client, userdata, mid, rc, properties)
-            
+        if self.on_publish:
+            self.on_publish(client, userdata, mid, rc, properties)
+
     def _on_subscribe_wrapper(self, client, userdata, mid, rc_list, properties):
-        if self.on_subscribe: self.on_subscribe(client, userdata, mid, rc_list, properties)
-            
+        if self.on_subscribe:
+            self.on_subscribe(client, userdata, mid, rc_list, properties)
+
     def _on_message_wrapper(self, client, userdata, msg):
         # Record INCOMING message
         try:
-            payload = msg.payload.decode('utf-8')
+            payload = msg.payload.decode("utf-8")
             # Try parsing JSON to store structured data
-            try: payload = json.loads(payload)
-            except json.JSONDecodeError: pass
+            try:
+                payload = json.loads(payload)
+            except json.JSONDecodeError:
+                pass
         except (UnicodeDecodeError, AttributeError):
             payload = str(msg.payload)
 
-        self.events.append({
-            'type': 'input',
-            'timestamp': time.time(),
-            'topic': msg.topic,
-            'payload': payload
-        })
-        if self.on_message: self.on_message(client, userdata, msg)
+        self.events.append(
+            {
+                "type": "input",
+                "timestamp": time.time(),
+                "topic": msg.topic,
+                "payload": payload,
+            }
+        )
+        if self.on_message:
+            self.on_message(client, userdata, msg)
         self.save_trace()
 
     def connect(self, host, port=1883, keepalive=60):
@@ -339,26 +385,26 @@ class RecorderTransport(Transport):
     def publish(self, topic, payload, qos=0):
         # Record OUTGOING message
         try:
-             # payload can be string or bytes
-             p = payload
-             if isinstance(p, bytes): p = p.decode('utf-8')
-             try: p = json.loads(p)
-             except json.JSONDecodeError: pass
+            # payload can be string or bytes
+            p = payload
+            if isinstance(p, bytes):
+                p = p.decode("utf-8")
+            try:
+                p = json.loads(p)
+            except json.JSONDecodeError:
+                pass
         except (UnicodeDecodeError, AttributeError):
-             p = str(payload)
+            p = str(payload)
 
-        self.events.append({
-            'type': 'output',
-            'timestamp': time.time(),
-            'topic': topic,
-            'payload': p
-        })
+        self.events.append(
+            {"type": "output", "timestamp": time.time(), "topic": topic, "payload": p}
+        )
         self.save_trace()
         return self.inner.publish(topic, payload, qos)
 
     def subscribe(self, topic):
         return self.inner.subscribe(topic)
-    
+
     def unsubscribe(self, topic):
         return self.inner.unsubscribe(topic)
 
@@ -371,19 +417,33 @@ class RecorderTransport(Transport):
 
     def save_trace(self):
         try:
-            with open(self.trace_file, 'w') as f:
+            with open(self.trace_file, "w") as f:
                 json.dump(self.events, f, indent=2)
         except Exception as e:
             print(f"Error saving trace: {e}")
 
     # Forward other methods
-    def username_pw_set(self, *args, **kwargs): self.inner.username_pw_set(*args, **kwargs)
-    def tls_set(self, *args, **kwargs): self.inner.tls_set(*args, **kwargs)
-    def tls_set_context(self, *args, **kwargs): self.inner.tls_set_context(*args, **kwargs)
-    def tls_insecure_set(self, *args, **kwargs): self.inner.tls_insecure_set(*args, **kwargs)
-    def message_callback_add(self, sub, callback): self.inner.message_callback_add(sub, callback)
-    def message_callback_remove(self, sub): self.inner.message_callback_remove(sub)
-    def socket(self): return self.inner.socket()
+    def username_pw_set(self, *args, **kwargs):
+        self.inner.username_pw_set(*args, **kwargs)
+
+    def tls_set(self, *args, **kwargs):
+        self.inner.tls_set(*args, **kwargs)
+
+    def tls_set_context(self, *args, **kwargs):
+        self.inner.tls_set_context(*args, **kwargs)
+
+    def tls_insecure_set(self, *args, **kwargs):
+        self.inner.tls_insecure_set(*args, **kwargs)
+
+    def message_callback_add(self, sub, callback):
+        self.inner.message_callback_add(sub, callback)
+
+    def message_callback_remove(self, sub):
+        self.inner.message_callback_remove(sub)
+
+    def socket(self):
+        return self.inner.socket()
+
     @property
-    def _out_packet(self): return self.inner._out_packet
-        
+    def _out_packet(self):
+        return self.inner._out_packet

--- a/arena/transport.py
+++ b/arena/transport.py
@@ -317,8 +317,8 @@ class RecorderTransport(Transport):
             payload = msg.payload.decode('utf-8')
             # Try parsing JSON to store structured data
             try: payload = json.loads(payload)
-            except: pass
-        except:
+            except json.JSONDecodeError: pass
+        except (UnicodeDecodeError, AttributeError):
             payload = str(msg.payload)
 
         self.events.append({
@@ -344,8 +344,8 @@ class RecorderTransport(Transport):
              p = payload
              if isinstance(p, bytes): p = p.decode('utf-8')
              try: p = json.loads(p)
-             except: pass
-        except:
+             except json.JSONDecodeError: pass
+        except (UnicodeDecodeError, AttributeError):
              p = str(payload)
 
         self.events.append({

--- a/arena/transport.py
+++ b/arena/transport.py
@@ -1,0 +1,390 @@
+from abc import ABC, abstractmethod
+import asyncio
+import socket
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import topic_matches_sub
+from .event_loop.asyncio_mqtt import AsyncioMQTTHelper
+import json
+import time
+
+class Transport(ABC):
+    """
+    Abstract base class for MQTT Transport.
+    """
+    def __init__(self):
+        self.on_connect = None
+        self.on_disconnect = None
+        self.on_publish = None
+        self.on_subscribe = None
+        self.on_message = None
+
+    @abstractmethod
+    def connect(self, host, port=1883, keepalive=60):
+        pass
+
+    @abstractmethod
+    def disconnect(self):
+        pass
+
+    @abstractmethod
+    def publish(self, topic, payload, qos=0):
+        pass
+
+    @abstractmethod
+    def subscribe(self, topic):
+        pass
+    
+    @abstractmethod
+    def unsubscribe(self, topic):
+        pass
+
+    @abstractmethod
+    def loop_start(self, event_loop):
+        """Starts the event loop integration."""
+        pass
+
+    @abstractmethod
+    def loop_stop(self):
+        """Stops the event loop integration."""
+        pass
+        
+    @abstractmethod
+    def username_pw_set(self, username, password=None):
+        pass
+
+    @abstractmethod
+    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None):
+        pass
+
+    @abstractmethod
+    def tls_set_context(self, context=None):
+        pass
+        
+    @abstractmethod
+    def tls_insecure_set(self, value):
+        pass
+    
+    @abstractmethod
+    def message_callback_add(self, sub, callback):
+        pass
+
+    @abstractmethod
+    def message_callback_remove(self, sub):
+        pass
+    
+    @abstractmethod
+    def socket(self):
+        pass
+        
+    @property
+    @abstractmethod
+    def _out_packet(self):
+         pass
+
+class PahoMQTTTransport(Transport):
+    """
+    Transport implementation using Paho MQTT Client.
+    """
+    def __init__(self, client_id, clean_session=True):
+        super().__init__()
+        self.mqttc = mqtt.Client(
+             mqtt.CallbackAPIVersion.VERSION2, client_id, clean_session=clean_session
+        )
+        self.aioh = None
+
+        # Proxy callbacks
+        self.mqttc.on_connect = self._on_connect_wrapper
+        self.mqttc.on_disconnect = self._on_disconnect_wrapper
+        self.mqttc.on_publish = self._on_publish_wrapper
+        self.mqttc.on_subscribe = self._on_subscribe_wrapper
+        self.mqttc.on_message = self._on_message_wrapper
+
+    def _on_connect_wrapper(self, client, userdata, flags, rc, properties):
+        if self.on_connect:
+            self.on_connect(client, userdata, flags, rc, properties)
+
+    def _on_disconnect_wrapper(self, client, userdata, rc, properties):
+        if self.on_disconnect:
+            self.on_disconnect(client, userdata, rc, properties)
+            
+    def _on_publish_wrapper(self, client, userdata, mid, rc, properties):
+        if self.on_publish:
+            self.on_publish(client, userdata, mid, rc, properties)
+            
+    def _on_subscribe_wrapper(self, client, userdata, mid, rc_list, properties):
+        if self.on_subscribe:
+            self.on_subscribe(client, userdata, mid, rc_list, properties)
+            
+    def _on_message_wrapper(self, client, userdata, msg):
+        if self.on_message:
+            self.on_message(client, userdata, msg)
+
+    def connect(self, host, port=1883, keepalive=60):
+        return self.mqttc.connect(host, port, keepalive)
+
+    def disconnect(self):
+        self.mqttc.disconnect()
+
+    def publish(self, topic, payload, qos=0):
+        return self.mqttc.publish(topic, payload, qos)
+
+    def subscribe(self, topic):
+        return self.mqttc.subscribe(topic)
+    
+    def unsubscribe(self, topic):
+        return self.mqttc.unsubscribe(topic)
+
+    def loop_start(self, event_loop):
+        self.aioh = AsyncioMQTTHelper(event_loop, self.mqttc)
+
+    def loop_stop(self):
+        # AsyncioMQTTHelper doesn't seem to have a clear stop/cleanup method exposed 
+        # but the event loop controls it.
+        pass
+
+    def username_pw_set(self, username, password=None):
+        self.mqttc.username_pw_set(username, password)
+
+    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None):
+        self.mqttc.tls_set(ca_certs, certfile, keyfile, cert_reqs, tls_version, ciphers)
+
+    def tls_set_context(self, context=None):
+        self.mqttc.tls_set_context(context)
+        
+    def tls_insecure_set(self, value):
+        self.mqttc.tls_insecure_set(value)
+
+    def message_callback_add(self, sub, callback):
+        self.mqttc.message_callback_add(sub, callback)
+    
+    def message_callback_remove(self, sub):
+        self.mqttc.message_callback_remove(sub)
+        
+    def socket(self):
+        return self.mqttc.socket()
+        
+    @property
+    def _out_packet(self):
+        return self.mqttc._out_packet
+
+class MockMQTTTransport(Transport):
+    """
+    Mock Transport for testing.
+    """
+    def __init__(self, client_id, clean_session=True):
+        super().__init__()
+        self.client_id = client_id
+        self.connected = False
+        self.subscriptions = {} # topic -> callback
+        self.published_messages = []
+        self._out_packet_mock = 0
+
+    def connect(self, host, port=1883, keepalive=60):
+        self.connected = True
+        # If event loop is already started, schedule the connection callback
+        if hasattr(self, 'event_loop') and self.event_loop:
+             self._schedule_connect()
+        return 0
+    
+
+    def disconnect(self):
+        self.connected = False
+        if self.on_disconnect:
+            self.on_disconnect(self, None, 0, None)
+
+    def publish(self, topic, payload, qos=0):
+        self.published_messages.append({'topic': topic, 'payload': payload, 'qos': qos})
+        if self.on_publish:
+            self.on_publish(self, None, 1, 0, None)
+        return None 
+
+    def subscribe(self, topic):
+        # mid=random
+        mid = 1
+        self.subscriptions[topic] = None # No specific callback added yet via add, just general sub
+        return (0, mid) # (result, mid)
+
+    def unsubscribe(self, topic):
+        if topic in self.subscriptions:
+            del self.subscriptions[topic]
+        return (0, 1)
+
+    def loop_start(self, event_loop):
+        self.loop_start_called = True
+        self.event_loop = event_loop
+        if self.connected:
+             self._schedule_connect()
+
+    def _schedule_connect(self):
+        # We need to trigger on_connect on the loop
+        async def _trigger():
+            await asyncio.sleep(0.01)
+            if self.on_connect:
+                self.on_connect(self, None, {}, 0, None)
+        
+        # We can add a task to the event_loop wrapper
+        from .event_loop import AsyncWorker
+        w = AsyncWorker(self.event_loop, _trigger, None)
+        self.event_loop.add_task(w)
+
+    def loop_stop(self):
+        pass
+
+    def username_pw_set(self, username, password=None):
+        pass
+
+    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None):
+        pass
+
+    def tls_set_context(self, context=None):
+        pass
+
+    def tls_insecure_set(self, value):
+        pass
+        
+    def message_callback_add(self, sub, callback):
+        # Store callback for this subscription
+        self.subscriptions[sub] = callback
+        
+    def message_callback_remove(self, sub):
+        if sub in self.subscriptions:
+            del self.subscriptions[sub]
+
+    def socket(self):
+        class MockSocket:
+            def setsockopt(self, *args, **kwargs): pass
+        return MockSocket()
+        
+    @property
+    def _out_packet(self):
+        return self._out_packet_mock
+
+    def mock_receive(self, topic, payload):
+        """Simulate receiving a message."""
+        # Simple mock message object
+        class MockMsg:
+            def __init__(self, t, p):
+                self.topic = t
+                self.payload = p
+                self.qos = 0
+                self.retain = False
+        
+        msg = MockMsg(topic, payload)
+        
+        # Find matching subscription
+        matched = False
+        for sub, callback in self.subscriptions.items():
+            if topic_matches_sub(sub, topic):
+                if callback:
+                    callback(self, None, msg)
+                    matched = True
+        
+        if not matched and self.on_message:
+            self.on_message(self, None, msg)
+
+class RecorderTransport(Transport):
+    """
+    Wraps another Transport to record input/output messages.
+    """
+    def __init__(self, inner_transport, trace_file="mqtt_trace.json"):
+        super().__init__()
+        self.inner = inner_transport
+        self.trace_file = trace_file
+        self.events = []
+        
+        # Proxy properties
+        self.inner.on_connect = self._on_connect_wrapper
+        self.inner.on_disconnect = self._on_disconnect_wrapper
+        self.inner.on_publish = self._on_publish_wrapper
+        self.inner.on_subscribe = self._on_subscribe_wrapper
+        self.inner.on_message = self._on_message_wrapper
+
+    def _on_connect_wrapper(self, client, userdata, flags, rc, properties):
+        if self.on_connect: self.on_connect(client, userdata, flags, rc, properties)
+
+    def _on_disconnect_wrapper(self, client, userdata, rc, properties):
+        if self.on_disconnect: self.on_disconnect(client, userdata, rc, properties)
+            
+    def _on_publish_wrapper(self, client, userdata, mid, rc, properties):
+        if self.on_publish: self.on_publish(client, userdata, mid, rc, properties)
+            
+    def _on_subscribe_wrapper(self, client, userdata, mid, rc_list, properties):
+        if self.on_subscribe: self.on_subscribe(client, userdata, mid, rc_list, properties)
+            
+    def _on_message_wrapper(self, client, userdata, msg):
+        # Record INCOMING message
+        try:
+            payload = msg.payload.decode('utf-8')
+            # Try parsing JSON to store structured data
+            try: payload = json.loads(payload)
+            except: pass
+        except:
+            payload = str(msg.payload)
+
+        self.events.append({
+            'type': 'input',
+            'timestamp': time.time(),
+            'topic': msg.topic,
+            'payload': payload
+        })
+        if self.on_message: self.on_message(client, userdata, msg)
+        self.save_trace()
+
+    def connect(self, host, port=1883, keepalive=60):
+        return self.inner.connect(host, port, keepalive)
+
+    def disconnect(self):
+        self.save_trace()
+        return self.inner.disconnect()
+
+    def publish(self, topic, payload, qos=0):
+        # Record OUTGOING message
+        try:
+             # payload can be string or bytes
+             p = payload
+             if isinstance(p, bytes): p = p.decode('utf-8')
+             try: p = json.loads(p)
+             except: pass
+        except:
+             p = str(payload)
+
+        self.events.append({
+            'type': 'output',
+            'timestamp': time.time(),
+            'topic': topic,
+            'payload': p
+        })
+        self.save_trace()
+        return self.inner.publish(topic, payload, qos)
+
+    def subscribe(self, topic):
+        return self.inner.subscribe(topic)
+    
+    def unsubscribe(self, topic):
+        return self.inner.unsubscribe(topic)
+
+    def loop_start(self, event_loop):
+        self.inner.loop_start(event_loop)
+
+    def loop_stop(self):
+        self.save_trace()
+        self.inner.loop_stop()
+
+    def save_trace(self):
+        try:
+            with open(self.trace_file, 'w') as f:
+                json.dump(self.events, f, indent=2)
+        except Exception as e:
+            print(f"Error saving trace: {e}")
+
+    # Forward other methods
+    def username_pw_set(self, *args, **kwargs): self.inner.username_pw_set(*args, **kwargs)
+    def tls_set(self, *args, **kwargs): self.inner.tls_set(*args, **kwargs)
+    def tls_set_context(self, *args, **kwargs): self.inner.tls_set_context(*args, **kwargs)
+    def tls_insecure_set(self, *args, **kwargs): self.inner.tls_insecure_set(*args, **kwargs)
+    def message_callback_add(self, sub, callback): self.inner.message_callback_add(sub, callback)
+    def message_callback_remove(self, sub): self.inner.message_callback_remove(sub)
+    def socket(self): return self.inner.socket()
+    @property
+    def _out_packet(self): return self.inner._out_packet
+        

--- a/arena/utils/program_info.py
+++ b/arena/utils/program_info.py
@@ -5,7 +5,7 @@ activity times and number of messages sent/received.
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, UTC
 
 from ..base_object import BaseObject
 from ..env import PROGRAM_STATS_UPDATE_INTERVAL_MS, _get_arena_env, _get_env
@@ -50,8 +50,8 @@ class ProgramRunInfo(BaseObject, GetPublicAttrsMixin):
         self.env=_get_arena_env()
 
         # run stats
-        self.create_time =  datetime.utcnow().isoformat()[:-3]+"Z"
-        self.last_active_time =  datetime.utcnow().isoformat()[:-3]+"Z"
+        self.create_time =  datetime.now(UTC).isoformat()[:-3]+"Z"
+        self.last_active_time =  datetime.now(UTC).isoformat()[:-3]+"Z"
         self.rcv_msgs = 0
         self.pub_msgs = 0
         # init when a message is sent/received (so we can see if messages were never sent/received)
@@ -108,13 +108,13 @@ class ProgramRunInfo(BaseObject, GetPublicAttrsMixin):
 
     def msg_rcv(self):
         """Update stats when a message is received. """
-        self.last_rcv_time = datetime.utcnow().isoformat()[:-3]+"Z"
+        self.last_rcv_time = datetime.now(UTC).isoformat()[:-3]+"Z"
         self.rcv_msgs = self.rcv_msgs + 1
         self.last_active_time = self.last_rcv_time
 
     def msg_publish(self):
         """Update stats when a message is published. """
-        self.last_pub_time = datetime.utcnow().isoformat()[:-3]+"Z"
+        self.last_pub_time = datetime.now(UTC).isoformat()[:-3]+"Z"
         self.pub_msgs = self.pub_msgs + 1
         self.last_active_time = self.last_pub_time
 

--- a/examples/random_sphere.py
+++ b/examples/random_sphere.py
@@ -3,13 +3,20 @@ import random
 
 scene = Scene(host="arenaxr.org", namespace="public", scene="random")
 
+
 def random_color():
-    return Color(red=random.random() * 255, green=random.random() * 255, blue=random.random() * 255)
+    return Color(
+        red=random.random() * 255,
+        green=random.random() * 255,
+        blue=random.random() * 255,
+    )
+
 
 def on_click(_scene, evt, _msg):
     if evt.type == "mousedown":
         print("Clicked! Changing color...")
         scene.update_object(sphere, material=Material(color=random_color()))
+
 
 sphere = Object(
     object_id="random_sphere",
@@ -18,7 +25,7 @@ sphere = Object(
     scale=Scale(0.5, 0.5, 0.5),
     material=Material(color=random_color()),
     clickable=True,
-    evt_handler=on_click
+    evt_handler=on_click,
 )
 
 scene.add_object(sphere)

--- a/examples/random_sphere.py
+++ b/examples/random_sphere.py
@@ -1,0 +1,25 @@
+from arena import *
+import random
+
+scene = Scene(host="arenaxr.org", namespace="public", scene="random")
+
+def random_color():
+    return Color(red=random.random() * 255, green=random.random() * 255, blue=random.random() * 255)
+
+def on_click(_scene, evt, _msg):
+    if evt.type == "mousedown":
+        print("Clicked! Changing color...")
+        scene.update_object(sphere, material=Material(color=random_color()))
+
+sphere = Object(
+    object_id="random_sphere",
+    object_type="sphere",
+    position=Position(0, 1.65, 1.75),
+    scale=Scale(0.5, 0.5, 0.5),
+    material=Material(color=random_color()),
+    clickable=True,
+    evt_handler=on_click
+)
+
+scene.add_object(sphere)
+scene.run_tasks()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,106 @@
+# ARENA-py Testing Infrastructure
+
+This directory contains the testing infrastructure for ARENA-py, enabling End-to-End (E2E) testing without requiring a live MQTT broker or network connection.
+
+## Overview
+
+The testing system uses a **Mock Transport** layer to simulate MQTT communication. This allows you to:
+1.  **Inject** incoming messages (simulating other clients or the server).
+2.  **Capture** outgoing messages (verifying your script's behavior).
+3.  **Mocks** authentication and persistence calls for a completely offline environment.
+
+## Running Tests
+
+You can run existing tests using unittest:
+
+```bash
+python -m unittest discover tests
+```
+
+To run a specific test:
+
+```bash
+python tests/test_e2e.py
+```
+
+## Creating New Tests
+
+We provide the `ArenaE2ETest` harness class in `arena.test_system`.
+
+### Basic Template
+
+```python
+import unittest
+from arena.test_system import ArenaE2ETest
+
+class TestMyFeature(unittest.IsolatedAsyncioTestCase):
+    async def test_my_logic(self):
+        # 1. Initialize Harness
+        harness = ArenaE2ETest(scene_name="test", namespace="public")
+        
+        # 2. Inject Setup Messages (optional)
+        # Simulate an object already existing
+        harness.inject_message("realm/s/public/test/o/box", {
+            "object_id": "box", "action": "create", "type": "object", "data": {...}
+        })
+        
+        # 3. Modify Scene (Your Code Under Test)
+        # direct access to harness.scene
+        harness.scene.add_object(Box(object_id="my_box"))
+        
+        # 4. Assert Output
+        msgs = harness.capture_published_messages()
+        self.assertTrue(any(m['payload']['object_id'] == "my_box" for m in msgs))
+```
+
+### Script Verification (Trace Driven)
+
+The recommended way to test scripts is using **Trace Verification**.
+1. Verify the script behaves correctly manually while recording a trace (env `ARENA_RECORD_TRACE=1`).
+2. Run the test harness against this trace using `verify_trace`.
+
+```python
+    async def test_trace(self):
+         harness = ArenaE2ETest("scene", "namespace")
+         # Intercept scene, run script...
+         await harness.verify_trace("trace.json")
+```
+
+This ensures that:
+- Every `output` in the trace is produced by the script (with matching payload).
+- Every `input` in the trace is injected into the script at the appropriate time (after preceding outputs are verified).
+
+### Manual Script Verification
+
+To verify an existing script manually:
+1.  **Mock the Scene**: Use `unittest.mock.patch` to intercept the script's `Scene` creation and route it to your harness.
+2.  **Import the Script**: Importing runs the script logic.
+3.  **Inject and Assert**: Use `harness.inject_message` to simulate user actions (like clicks) and check for expected responses.
+    *   *See `tests/test_random_sphere.py` for a complete example.*
+
+## Record and Replay
+
+You can capture "traces" from a real live session and use them for regression testing.
+
+### 1. Recording
+Run your script with `ARENA_RECORD_TRACE=1`. This will generate `mqtt_trace.json`.
+
+```bash
+export ARENA_RECORD_TRACE=1
+python examples/my_script.py
+```
+
+### 2. Replaying
+The replay runner will re-inject the inputs recorded in the trace.
+
+```bash
+export ARENA_TRACE_FILE=mqtt_trace.json
+python tests/test_replay.py
+```
+
+Note: Replaying checks that the script doesn't crash but does not automatically verify complex logic unless extended.
+
+## Key Components
+
+*   **`arena/transport.py`**: Defines the `Transport` interface, `PahoMQTTTransport` (production), and `MockMQTTTransport` (testing).
+*   **`arena/test_system.py`**: Defines `ArenaE2ETest`, which sets up a `Scene` with the mock transport and default configuration.

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,27 +7,107 @@ This directory contains the testing infrastructure for ARENA-py, enabling End-to
 The testing system uses a **Mock Transport** layer to simulate MQTT communication. This allows you to:
 1.  **Inject** incoming messages (simulating other clients or the server).
 2.  **Capture** outgoing messages (verifying your script's behavior).
-3.  **Mocks** authentication and persistence calls for a completely offline environment.
+3.  **Mock** authentication and persistence calls for a completely offline environment.
 
 ## Running Tests
-
-You can run existing tests using unittest:
 
 ```bash
 python -m unittest discover tests
 ```
 
-To run a specific test:
+Or run a specific test:
 
 ```bash
-python tests/test_e2e.py
+python tests/test_random_sphere.py
 ```
 
-## Creating New Tests
+## Quick Start: Testing Existing Scripts
 
-We provide the `ArenaE2ETest` harness class in `arena.test_system`.
+The simplest way to test an existing script is using `run_script()`:
 
-### Basic Template
+```python
+from arena.test_system import ArenaE2ETest
+
+ArenaE2ETest.run_script(
+    script_path="examples/random_sphere.py",
+    trace_path="tests/trace_random_sphere.json",
+    scene_name="random",
+    namespace="public"
+)
+```
+
+This will:
+1. Load your script with a mock Scene
+2. Execute the script logic
+3. Replay inputs from the trace and verify outputs match
+
+## Recording Traces
+
+Record a trace from a live session:
+
+```bash
+export ARENA_RECORD_TRACE=1
+python examples/my_script.py
+# Produces: mqtt_trace.json
+```
+
+The trace captures all MQTT inputs (messages received) and outputs (messages sent).
+
+## Trace Format
+
+```json
+[
+    {"type": "output", "topic": "...", "payload": {...}},
+    {"type": "input", "topic": "...", "payload": {...}},
+    {"type": "output", "topic": "...", "payload": {...}}
+]
+```
+
+**Verification behavior:**
+- Fields in the trace are checked for **exact match** against actual output
+- Empty objects `{}` act as wildcards (e.g., `"material": {}` matches any material)
+- Timestamp fields are automatically ignored
+
+## Custom Validation with Callbacks
+
+For complex logic (e.g., verifying positions, tracking state), use callbacks:
+
+```python
+def track_position(event_idx, expected, actual):
+    """Called when a trace output matches."""
+    if actual.get("object_id") == "moving_box":
+        pos = actual["data"]["position"]
+        assert pos["x"] >= 0, "Box should stay in positive X"
+
+ArenaE2ETest.run_script(
+    script_path="examples/moving_box.py",
+    trace_path="traces/moving_box.json",
+    on_output_match=track_position,  # Called for matched outputs
+    # on_any_output=log_all,         # Called for ALL captured outputs
+)
+```
+
+**Callbacks:**
+| Callback | Signature | When it fires |
+|----------|-----------|---------------|
+| `on_output_match` | `(event_idx, expected, actual)` | When a trace output is matched |
+| `on_any_output` | `(actual)` | For every captured output message |
+
+## Test Suite: Multiple Scripts
+
+Test multiple scripts at once:
+
+```python
+results = ArenaE2ETest.run_test_suite([
+    {"script": "examples/random_sphere.py", "trace": "traces/random_sphere.json"},
+    {"script": "examples/box_click.py", "trace": "traces/box_click.json", "scene_name": "click"},
+])
+# results = {"passed": 2, "failed": 0, "results": [...]}
+```
+
+## Manual Testing (Advanced)
+
+For direct control, use the harness directly:
 
 ```python
 import unittest
@@ -35,72 +115,23 @@ from arena.test_system import ArenaE2ETest
 
 class TestMyFeature(unittest.IsolatedAsyncioTestCase):
     async def test_my_logic(self):
-        # 1. Initialize Harness
         harness = ArenaE2ETest(scene_name="test", namespace="public")
         
-        # 2. Inject Setup Messages (optional)
-        # Simulate an object already existing
-        harness.inject_message("realm/s/public/test/o/box", {
-            "object_id": "box", "action": "create", "type": "object", "data": {...}
-        })
-        
-        # 3. Modify Scene (Your Code Under Test)
-        # direct access to harness.scene
+        # Add objects directly
         harness.scene.add_object(Box(object_id="my_box"))
         
-        # 4. Assert Output
+        # Wait for processing
+        await harness.run_step(0.1)
+        
+        # Check outputs
         msgs = harness.capture_published_messages()
-        self.assertTrue(any(m['payload']['object_id'] == "my_box" for m in msgs))
+        self.assertTrue(any(m["payload"]["object_id"] == "my_box" for m in msgs))
 ```
-
-### Script Verification (Trace Driven)
-
-The recommended way to test scripts is using **Trace Verification**.
-1. Verify the script behaves correctly manually while recording a trace (env `ARENA_RECORD_TRACE=1`).
-2. Run the test harness against this trace using `verify_trace`.
-
-```python
-    async def test_trace(self):
-         harness = ArenaE2ETest(scene_name="scene", namespace="namespace")
-         # Intercept scene, run script...
-         await harness.verify_trace("trace.json")
-```
-
-This ensures that:
-- Every `output` in the trace is produced by the script (with matching payload).
-- Every `input` in the trace is injected into the script at the appropriate time (after preceding outputs are verified).
-
-### Manual Script Verification
-
-To verify an existing script manually:
-1.  **Mock the Scene**: Use `unittest.mock.patch` to intercept the script's `Scene` creation and route it to your harness.
-2.  **Import the Script**: Importing runs the script logic.
-3.  **Inject and Assert**: Use `harness.inject_message` to simulate user actions (like clicks) and check for expected responses.
-    *   *See `tests/test_random_sphere.py` for a complete example.*
-
-## Record and Replay
-
-You can capture "traces" from a real live session and use them for regression testing.
-
-### 1. Recording
-Run your script with `ARENA_RECORD_TRACE=1`. This will generate `mqtt_trace.json`.
-
-```bash
-export ARENA_RECORD_TRACE=1
-python examples/my_script.py
-```
-
-### 2. Replaying
-The replay runner will re-inject the inputs recorded in the trace.
-
-```bash
-export ARENA_TRACE_FILE=mqtt_trace.json
-python tests/test_replay.py
-```
-
-Note: Replaying checks that the script doesn't crash but does not automatically verify complex logic unless extended.
 
 ## Key Components
 
-*   **`arena/transport.py`**: Defines the `Transport` interface, `PahoMQTTTransport` (production), and `MockMQTTTransport` (testing).
-*   **`arena/test_system.py`**: Defines `ArenaE2ETest`, which sets up a `Scene` with the mock transport and default configuration.
+| File | Description |
+|------|-------------|
+| `arena/transport.py` | `Transport` interface, `PahoMQTTTransport` (production), `MockMQTTTransport` (testing) |
+| `arena/test_system.py` | `ArenaE2ETest` harness with `run_script()`, `verify_trace()`, `run_test_suite()` |
+| `tests/trace_*.json` | Recorded traces for regression testing |

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,7 +61,7 @@ The recommended way to test scripts is using **Trace Verification**.
 
 ```python
     async def test_trace(self):
-         harness = ArenaE2ETest("scene", "namespace")
+         harness = ArenaE2ETest(scene_name="scene", namespace="namespace")
          # Intercept scene, run script...
          await harness.verify_trace("trace.json")
 ```

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -4,6 +4,7 @@ import os
 from arena.test_system import ArenaE2ETest
 from arena.objects import Object
 
+
 class TestArenaE2E(unittest.IsolatedAsyncioTestCase):
     async def test_e2e_flow(self):
         """
@@ -13,43 +14,52 @@ class TestArenaE2E(unittest.IsolatedAsyncioTestCase):
         # 1. Initialize Harness
         harness = ArenaE2ETest(scene_name="test_scene", realm="realm", namespace="user")
         print(f"\n[Test] Harness started. Mock Scene: {harness.scene_name}")
-        
+
         # 2. Script Action: Create Object
         # We simulate the script logic directly here
         print("[Test] Script Action: create object box1")
-        box = Object(object_id="box1", object_type="box", position={"x":0, "y":1, "z":-2})
+        box = Object(
+            object_id="box1", object_type="box", position={"x": 0, "y": 1, "z": -2}
+        )
         harness.scene.add_object(box)
-        
+
         # 3. Wait for network simulation
         print("[Test] Sleeping 0.1s...")
         await harness.run_step(0.1)
-        
+
         # 4. Verify Output
         print("[Test] Verifying output...")
         published = harness.capture_published_messages()
-        
+
         # Look for the creation message
         found_msg = None
         for msg in published:
             # Decode payload
-            payload = msg['payload']
-            if isinstance(payload, bytes): payload = payload.decode('utf-8')
+            payload = msg["payload"]
+            if isinstance(payload, bytes):
+                payload = payload.decode("utf-8")
             if isinstance(payload, str):
-                try: payload = json.loads(payload)
-                except json.JSONDecodeError: pass
-                
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    pass
+
             if isinstance(payload, dict):
-                if payload.get('object_id') == "box1" and payload.get('action') == "create":
+                if (
+                    payload.get("object_id") == "box1"
+                    and payload.get("action") == "create"
+                ):
                     found_msg = payload
                     break
-        
+
         if found_msg:
             print(f"[Test] Found expected message: {found_msg}")
         else:
             print(f"[Test] FAILED: Did not find creation message for box1")
-            
-        self.assertIsNotNone(found_msg, "Expected creation message for box1 not found")
-        self.assertEqual(found_msg['data']['object_type'], "box")
 
-if __name__ == '__main__':
+        self.assertIsNotNone(found_msg, "Expected creation message for box1 not found")
+        self.assertEqual(found_msg["data"]["object_type"], "box")
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,8 +1,6 @@
 import json
 import unittest
-import sys
 import os
-import asyncio
 from arena.test_system import ArenaE2ETest
 from arena.objects import Object
 
@@ -38,7 +36,7 @@ class TestArenaE2E(unittest.IsolatedAsyncioTestCase):
             if isinstance(payload, bytes): payload = payload.decode('utf-8')
             if isinstance(payload, str):
                 try: payload = json.loads(payload)
-                except: pass
+                except json.JSONDecodeError: pass
                 
             if isinstance(payload, dict):
                 if payload.get('object_id') == "box1" and payload.get('action') == "create":

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,57 @@
+import json
+import unittest
+import sys
+import os
+import asyncio
+from arena.test_system import ArenaE2ETest
+from arena.objects import Object
+
+class TestArenaE2E(unittest.IsolatedAsyncioTestCase):
+    async def test_e2e_flow(self):
+        """
+        Demonstrates a manual E2E test without using a trace file.
+        Useful for programmatic verification of features.
+        """
+        # 1. Initialize Harness
+        harness = ArenaE2ETest(scene_name="test_scene", realm="realm", namespace="user")
+        print(f"\n[Test] Harness started. Mock Scene: {harness.scene_name}")
+        
+        # 2. Script Action: Create Object
+        # We simulate the script logic directly here
+        print("[Test] Script Action: create object box1")
+        box = Object(object_id="box1", object_type="box", position={"x":0, "y":1, "z":-2})
+        harness.scene.add_object(box)
+        
+        # 3. Wait for network simulation
+        print("[Test] Sleeping 0.1s...")
+        await harness.run_step(0.1)
+        
+        # 4. Verify Output
+        print("[Test] Verifying output...")
+        published = harness.capture_published_messages()
+        
+        # Look for the creation message
+        found_msg = None
+        for msg in published:
+            # Decode payload
+            payload = msg['payload']
+            if isinstance(payload, bytes): payload = payload.decode('utf-8')
+            if isinstance(payload, str):
+                try: payload = json.loads(payload)
+                except: pass
+                
+            if isinstance(payload, dict):
+                if payload.get('object_id') == "box1" and payload.get('action') == "create":
+                    found_msg = payload
+                    break
+        
+        if found_msg:
+            print(f"[Test] Found expected message: {found_msg}")
+        else:
+            print(f"[Test] FAILED: Did not find creation message for box1")
+            
+        self.assertIsNotNone(found_msg, "Expected creation message for box1 not found")
+        self.assertEqual(found_msg['data']['object_type'], "box")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_random_sphere.py
+++ b/tests/test_random_sphere.py
@@ -10,14 +10,32 @@ class TestRandomSphere(unittest.TestCase):
         Verifies:
         1. Sphere is created with object_type="sphere"
         2. Click event is processed (mousedown on target)
-        3. Sphere is updated with a material change
+        3. Sphere is updated with a DIFFERENT color than initial
         """
+        colors_seen = []
+        
+        def track_color(event_idx, expected, actual):
+            """Track sphere colors across matched outputs."""
+            if actual.get("object_id") == "random_sphere":
+                material = actual.get("data", {}).get("material", {})
+                color = material.get("color")
+                if color:
+                    colors_seen.append(color)
+                    print(f"[Color Check] Output {event_idx}: color={color}")
+        
         ArenaE2ETest.run_script(
             script_path="examples/random_sphere.py",
             trace_path="tests/trace_random_sphere.json",
+            on_output_match=track_color,
             scene_name="random",
             namespace="public"
         )
+        
+        # Verify that we saw at least 2 colors and they are different
+        if len(colors_seen) >= 2:
+            assert colors_seen[0] != colors_seen[1], \
+                f"Color should change after click: initial={colors_seen[0]}, after={colors_seen[1]}"
+            print(f"[Color Check] ✓ Color changed from {colors_seen[0]} to {colors_seen[1]}")
 
 
 if __name__ == '__main__':

--- a/tests/test_random_sphere.py
+++ b/tests/test_random_sphere.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+import json
+import asyncio
+
+# Add examples to path so we can import random_sphere
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'examples')))
+
+from arena.test_system import ArenaE2ETest
+from arena.transport import MockMQTTTransport
+from arena.objects import Object
+
+class TestRandomSphere(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        # Clear global object registry to ensure clean state
+        Object.all_objects = {}
+        Object.private_objects = {}
+
+    async def test_random_sphere_logic(self):
+        # 1. Setup the Harness (Mock Transport, etc)
+        # We need to bridge the script's Scene instantiation to our harness.
+        # The script does: scene = Scene(...)
+        
+        # We'll create our harness first.
+        harness = ArenaE2ETest(scene_name="random", namespace="public")
+        harness.scene.debug = True # Enable debug to trace message processing
+        
+        # Bridge script's Scene instantiation to our harness
+        
+        with patch('arena.Scene') as MockSceneClass:
+            # Mock Scene methods to prevent actual execution blocking
+            MockSceneClass.return_value = harness.scene
+            harness.scene.run_tasks = MagicMock()
+            
+            # 2. Run the script
+            import random_sphere
+            
+            # 3. Verify Execution against Trace
+            try:
+                # Need to use absolute path or relative to CWD if running from root
+                await harness.verify_trace("tests/trace_random_sphere.json")
+            except AssertionError as e:
+                self.fail(f"Trace verification failed: {e}")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_random_sphere.py
+++ b/tests/test_random_sphere.py
@@ -6,14 +6,14 @@ class TestRandomSphere(unittest.TestCase):
     def test_random_sphere_logic(self):
         """
         Test random_sphere.py against its recorded trace.
-        
+
         Verifies:
         1. Sphere is created with object_type="sphere"
         2. Click event is processed (mousedown on target)
         3. Sphere is updated with a DIFFERENT color than initial
         """
         colors_seen = []
-        
+
         def track_color(event_idx, expected, actual):
             """Track sphere colors across matched outputs."""
             if actual.get("object_id") == "random_sphere":
@@ -22,21 +22,24 @@ class TestRandomSphere(unittest.TestCase):
                 if color:
                     colors_seen.append(color)
                     print(f"[Color Check] Output {event_idx}: color={color}")
-        
+
         ArenaE2ETest.run_script(
             script_path="examples/random_sphere.py",
             trace_path="tests/trace_random_sphere.json",
             on_output_match=track_color,
             scene_name="random",
-            namespace="public"
+            namespace="public",
         )
-        
+
         # Verify that we saw at least 2 colors and they are different
         if len(colors_seen) >= 2:
-            assert colors_seen[0] != colors_seen[1], \
+            assert colors_seen[0] != colors_seen[1], (
                 f"Color should change after click: initial={colors_seen[0]}, after={colors_seen[1]}"
-            print(f"[Color Check] ✓ Color changed from {colors_seen[0]} to {colors_seen[1]}")
+            )
+            print(
+                f"[Color Check] ✓ Color changed from {colors_seen[0]} to {colors_seen[1]}"
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_random_sphere.py
+++ b/tests/test_random_sphere.py
@@ -2,8 +2,6 @@ import unittest
 from unittest.mock import patch, MagicMock
 import os
 import sys
-import json
-import asyncio
 
 # Add examples to path so we can import random_sphere
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'examples')))

--- a/tests/test_random_sphere.py
+++ b/tests/test_random_sphere.py
@@ -1,46 +1,24 @@
 import unittest
-from unittest.mock import patch, MagicMock
-import os
-import sys
-
-# Add examples to path so we can import random_sphere
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'examples')))
-
 from arena.test_system import ArenaE2ETest
-from arena.transport import MockMQTTTransport
-from arena.objects import Object
 
-class TestRandomSphere(unittest.IsolatedAsyncioTestCase):
-    async def asyncSetUp(self):
-        # Clear global object registry to ensure clean state
-        Object.all_objects = {}
-        Object.private_objects = {}
 
-    async def test_random_sphere_logic(self):
-        # 1. Setup the Harness (Mock Transport, etc)
-        # We need to bridge the script's Scene instantiation to our harness.
-        # The script does: scene = Scene(...)
+class TestRandomSphere(unittest.TestCase):
+    def test_random_sphere_logic(self):
+        """
+        Test random_sphere.py against its recorded trace.
         
-        # We'll create our harness first.
-        harness = ArenaE2ETest(scene_name="random", namespace="public")
-        harness.scene.debug = True # Enable debug to trace message processing
-        
-        # Bridge script's Scene instantiation to our harness
-        
-        with patch('arena.Scene') as MockSceneClass:
-            # Mock Scene methods to prevent actual execution blocking
-            MockSceneClass.return_value = harness.scene
-            harness.scene.run_tasks = MagicMock()
-            
-            # 2. Run the script
-            import random_sphere
-            
-            # 3. Verify Execution against Trace
-            try:
-                # Need to use absolute path or relative to CWD if running from root
-                await harness.verify_trace("tests/trace_random_sphere.json")
-            except AssertionError as e:
-                self.fail(f"Trace verification failed: {e}")
+        Verifies:
+        1. Sphere is created with object_type="sphere"
+        2. Click event is processed (mousedown on target)
+        3. Sphere is updated with a material change
+        """
+        ArenaE2ETest.run_script(
+            script_path="examples/random_sphere.py",
+            trace_path="tests/trace_random_sphere.json",
+            scene_name="random",
+            namespace="public"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,54 @@
+import unittest
+import json
+import asyncio
+import os
+from arena.test_system import ArenaE2ETest
+
+class TestArenaReplay(unittest.IsolatedAsyncioTestCase):
+    async def test_replay_trace(self):
+        trace_file = os.environ.get("ARENA_TRACE_FILE", "mqtt_trace.json")
+        if not os.path.exists(trace_file):
+            print(f"No trace file found at {trace_file}. Skipping replay test.")
+            return
+
+        print(f"Loading trace from {trace_file}...")
+        with open(trace_file, 'r') as f:
+            events = json.load(f)
+
+        if not events:
+            print("Trace file is empty.")
+            return
+
+        # Setup harness
+        harness = ArenaE2ETest(scene_name="test_scene", realm="realm", namespace="user")
+        
+        print(f"Replaying {len(events)} events...")
+        for i, event in enumerate(events):
+            if event['type'] == 'input':
+                # Message that was received by the client in the trace
+                # In replay, we inject it so the client receives it again
+                print(f"[{i}] Injecting input: {event['topic']}")
+                harness.inject_message(event['topic'], event['payload'])
+                # Give it a moment to process
+                await harness.run_step(0.01)
+
+            elif event['type'] == 'output':
+                # Message that was sent by the client in the trace
+                # In replay, we expect the client to produce this (or similar)
+                # Note: Exact timing/ordering might vary unless we are strictly deterministic
+                # For now, we can just log that we saw it in trace vs what we captured.
+                # True verification requires asserting that the system state matches or
+                # that we capture a matching message from the mock transport.
+                print(f"[{i}] Trace contained output: {event['topic']}")
+                
+                # Check if we captured a matching message recently
+                captured = harness.capture_published_messages()
+                # Simple check: Is there any message with matching topic?
+                # A robust replay validation is complex.
+                # For this basic implementation, we just ensure no crashes.
+                pass
+                
+        print("Replay complete.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,54 +1,21 @@
 import unittest
-import json
-import asyncio
 import os
 from arena.test_system import ArenaE2ETest
 
+
 class TestArenaReplay(unittest.IsolatedAsyncioTestCase):
     async def test_replay_trace(self):
+        """
+        Replay a recorded trace file and verify outputs match.
+        Set ARENA_TRACE_FILE env var to specify trace file path.
+        """
         trace_file = os.environ.get("ARENA_TRACE_FILE", "mqtt_trace.json")
         if not os.path.exists(trace_file):
-            print(f"No trace file found at {trace_file}. Skipping replay test.")
-            return
+            self.skipTest(f"No trace file found at {trace_file}")
 
-        print(f"Loading trace from {trace_file}...")
-        with open(trace_file, 'r') as f:
-            events = json.load(f)
-
-        if not events:
-            print("Trace file is empty.")
-            return
-
-        # Setup harness
         harness = ArenaE2ETest(scene_name="test_scene", realm="realm", namespace="user")
-        
-        print(f"Replaying {len(events)} events...")
-        for i, event in enumerate(events):
-            if event['type'] == 'input':
-                # Message that was received by the client in the trace
-                # In replay, we inject it so the client receives it again
-                print(f"[{i}] Injecting input: {event['topic']}")
-                harness.inject_message(event['topic'], event['payload'])
-                # Give it a moment to process
-                await harness.run_step(0.01)
+        await harness.verify_trace(trace_file)
 
-            elif event['type'] == 'output':
-                # Message that was sent by the client in the trace
-                # In replay, we expect the client to produce this (or similar)
-                # Note: Exact timing/ordering might vary unless we are strictly deterministic
-                # For now, we can just log that we saw it in trace vs what we captured.
-                # True verification requires asserting that the system state matches or
-                # that we capture a matching message from the mock transport.
-                print(f"[{i}] Trace contained output: {event['topic']}")
-                
-                # Check if we captured a matching message recently
-                captured = harness.capture_published_messages()
-                # Simple check: Is there any message with matching topic?
-                # A robust replay validation is complex.
-                # For this basic implementation, we just ensure no crashes.
-                pass
-                
-        print("Replay complete.")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -17,5 +17,5 @@ class TestArenaReplay(unittest.IsolatedAsyncioTestCase):
         await harness.verify_trace(trace_file)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/trace_random_sphere.json
+++ b/tests/trace_random_sphere.json
@@ -1,0 +1,53 @@
+[
+    {
+        "type": "output",
+        "timestamp": 1734394000.0,
+        "topic": "realm/s/public/random/o/Ivan_3408843026_py/random_sphere",
+        "payload": {
+            "object_id": "random_sphere",
+            "action": "create",
+            "type": "object",
+            "data": {
+                "object_type": "sphere"
+            }
+        }
+    },
+    {
+        "type": "input",
+        "timestamp": 1734394010.0,
+        "topic": "realm/s/public/random/u/Ivan_2934834634_web/Ivan_2934834634",
+        "payload": {
+            "object_id": "Ivan_2934834634",
+            "action": "clientEvent",
+            "type": "mousedown",
+            "data": {
+                "originPosition": {
+                    "x": 0,
+                    "y": 1.6,
+                    "z": 0
+                },
+                "targetPosition": {
+                    "x": -0.133,
+                    "y": 1.723,
+                    "z": 1.276
+                },
+                "target": "random_sphere"
+            },
+            "timestamp": "2025-12-16T22:11:11.001Z"
+        }
+    },
+    {
+        "type": "output",
+        "timestamp": 1734394011.0,
+        "topic": "realm/s/public/random/o/Ivan_3408843026_py/random_sphere",
+        "payload": {
+            "object_id": "random_sphere",
+            "action": "update",
+            "type": "object",
+            "data": {
+                "object_type": "sphere",
+                "material": {}
+            }
+        }
+    }
+]


### PR DESCRIPTION
Refactors the `arena` library to decouple the MQTT messaging layer from the core [ArenaMQTT](arena/arena_mqtt.py#19-383) and [Scene](arena/scene.py#32-807) logic. previously, `paho.mqtt` was instantiated directly within [ArenaMQTT](arena/arena_mqtt.py#19-383), making it impossible to test without a live network connection.

**Key Changes:**
1.  **Transport Abstraction**: Created a new [Transport](arena/transport.py#10-83) abstract base class ([arena/transport.py](arena/transport.py)).
2.  **Paho Encapsulation**: Moved existing Paho logic into [PahoMQTTTransport](arena/transport.py#84-169) which implements the [Transport](arena/transport.py#10-83) interface.
3.  **Dependency Injection**: Updated `ArenaMQTT.__init__` to accept an optional `transport` argument.
4.  **Mocking Support**: Implemented [MockMQTTTransport](arena/transport.py#170-284) and [RecorderTransport](arena/transport.py#285-390) to support offline E2E testing and trace recording.

This architecture allows the test harness ([ArenaE2ETest](arena/test_system.py#8-181)) to inject a [MockMQTTTransport](arena/transport.py#170-284) into the [Scene](arena/scene.py#32-807), enabling fully offline verification of scene logic, message publishing, and event handling.

## E2E testing:

See [test readme](tests/README.md) 