### PR TITLE
feat: diff update msgs for deltas only

### DIFF
--- a/arena/delta.py
+++ b/arena/delta.py
@@ -1,0 +1,63 @@
+"""
+Delta compression for ARENA MQTT messages.
+
+Computes the minimal diff between two JSON-serialized data dicts,
+returning only changed fields. Used on the outbound publish path
+to reduce MQTT payload sizes.
+"""
+
+
+def deep_diff(prev, next_val):
+    """Compute the minimal delta between two data dicts.
+
+    Both inputs must be JSON-primitive dicts (str, int, float, bool,
+    None, dict, list — no custom objects). This is guaranteed when
+    called after Object.json() serialization.
+
+    Rules:
+        - Recurse into nested dicts; identical sub-dicts are omitted.
+        - None is a semantic delete and always flows through.
+          None → None is a no-op (omitted).
+        - Arrays compared by value (Python == does deep equality).
+        - Keys in next_val but not prev are new → included.
+        - Keys in prev but not next_val are removed → emitted as None.
+
+    Args:
+        prev: Previously published data dict.
+        next_val: Current data dict to publish.
+
+    Returns:
+        Dict containing only changed fields. Empty {} means no changes.
+    """
+    diff = {}
+
+    # Keys present in next_val: check for changes or additions
+    for key, nv in next_val.items():
+        if key not in prev:
+            # New field
+            diff[key] = nv
+            continue
+
+        pv = prev[key]
+
+        # Both None → no-op (already deleted)
+        if pv is None and nv is None:
+            continue
+
+        # Recurse into nested dicts
+        if isinstance(pv, dict) and isinstance(nv, dict):
+            sub = deep_diff(pv, nv)
+            if sub:  # Only include if something changed
+                diff[key] = sub
+            continue
+
+        # Primitives / lists: Python == handles deep equality
+        if pv != nv:
+            diff[key] = nv
+
+    # Keys in prev but not next_val → semantic delete
+    for key in prev:
+        if key not in next_val:
+            diff[key] = None
+
+    return diff

--- a/arena/device.py
+++ b/arena/device.py
@@ -69,20 +69,21 @@ class Device(ArenaMQTT):
 
     def publish(self, topic, payload_obj):
         """Publishes to mqtt broker."""
-        # Apply delta compression only for structured dict payloads.
+        # Apply delta compression only for structured dict payloads with valid ARENA messages.
         # Pre-serialized payloads (for example JSON strings published on
         # custom topics) should be passed through unchanged.
+        # Skip delta compression if action is missing (indicates custom/partial payloads).
         if self.delta_compression and isinstance(payload_obj, dict):
             object_id = payload_obj.get("object_id")
             action = payload_obj.get("action")
             data = payload_obj.get("data")
 
-            if object_id and data is not None:
+            if object_id and action and data is not None:
                 if action == "delete":
                     self._last_published_state.pop(object_id, None)
                 elif action == "create" or object_id not in self._last_published_state:
                     self._last_published_state[object_id] = copy.deepcopy(data)
-                elif action == "update":
+                elif action == "update" and isinstance(data, dict):
                     prev_data = self._last_published_state[object_id]
                     delta = deep_diff(prev_data, data)
                     self._last_published_state[object_id] = copy.deepcopy(data)

--- a/arena/device.py
+++ b/arena/device.py
@@ -67,8 +67,10 @@ class Device(ArenaMQTT):
 
     def publish(self, topic, payload_obj):
         """Publishes to mqtt broker."""
-        # Apply delta compression if enabled
-        if self.delta_compression:
+        # Apply delta compression only for structured dict payloads.
+        # Pre-serialized payloads (for example JSON strings published on
+        # custom topics) should be passed through unchanged.
+        if self.delta_compression and isinstance(payload_obj, dict):
             object_id = payload_obj.get("object_id")
             action = payload_obj.get("action")
             data = payload_obj.get("data")
@@ -86,7 +88,7 @@ class Device(ArenaMQTT):
                     self._last_published_state[object_id] = copy.deepcopy(data)
                     payload_obj = {**payload_obj, "data": delta}
 
-        payload = json.dumps(payload_obj)
+        payload = json.dumps(payload_obj) if isinstance(payload_obj, dict) else payload_obj
         self.transport.publish(topic, payload, qos=0)
         if self.debug:
             print(f"[publish] {topic} {payload}")

--- a/arena/device.py
+++ b/arena/device.py
@@ -22,6 +22,7 @@ class Device(ArenaMQTT):
     :param func on_msg_callback: Called on all MQTT messages received (optional).
     :param func end_program_callback: Called on MQTT disconnect (optional).
     :param bool debug: If true, print a log of all publish messages from this client (optional).
+    :param bool delta_compression: If true, publish update messages using delta compression by tracking the last published state for each object and sending only changed fields in the ``data`` payload. Defaults to True, which changes publish behavior from sending full update payloads to sending diffs for ``update`` actions (optional).
     """
 
     def __init__(

--- a/arena/device.py
+++ b/arena/device.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import re
@@ -79,10 +80,8 @@ class Device(ArenaMQTT):
                 if action == "delete":
                     self._last_published_state.pop(object_id, None)
                 elif action == "create" or object_id not in self._last_published_state:
-                    import copy
                     self._last_published_state[object_id] = copy.deepcopy(data)
                 elif action == "update":
-                    import copy
                     prev_data = self._last_published_state[object_id]
                     delta = deep_diff(prev_data, data)
                     self._last_published_state[object_id] = copy.deepcopy(data)

--- a/arena/device.py
+++ b/arena/device.py
@@ -4,6 +4,7 @@ import re
 import sys
 
 from .arena_mqtt import ArenaMQTT
+from .delta import deep_diff
 from .env import DEVICE, _get_env
 
 
@@ -30,6 +31,7 @@ class Device(ArenaMQTT):
         on_msg_callback=None,
         end_program_callback=None,
         debug=False,
+        delta_compression=True,
         **kwargs,
     ):
 
@@ -47,6 +49,10 @@ class Device(ArenaMQTT):
         super().__init__(host, realm, network_latency_interval, on_msg_callback, end_program_callback, debug, **kwargs)
         print(f"Device topic ready: {self.realm}/d/{self.namespace}/{self.device}, mqtt_host={self.mqtt_host}")
 
+        # Delta compression: shadow map of last-published data dicts
+        self.delta_compression = delta_compression
+        self._last_published_state = {}  # object_id -> data dict
+
     async def process_message(self):
         while True:
             msg = await self.msg_queue.get()
@@ -61,6 +67,25 @@ class Device(ArenaMQTT):
 
     def publish(self, topic, payload_obj):
         """Publishes to mqtt broker."""
+        # Apply delta compression if enabled
+        if self.delta_compression:
+            object_id = payload_obj.get("object_id")
+            action = payload_obj.get("action")
+            data = payload_obj.get("data")
+
+            if object_id and data is not None:
+                if action == "delete":
+                    self._last_published_state.pop(object_id, None)
+                elif action == "create" or object_id not in self._last_published_state:
+                    import copy
+                    self._last_published_state[object_id] = copy.deepcopy(data)
+                elif action == "update":
+                    import copy
+                    prev_data = self._last_published_state[object_id]
+                    delta = deep_diff(prev_data, data)
+                    self._last_published_state[object_id] = copy.deepcopy(data)
+                    payload_obj = {**payload_obj, "data": delta}
+
         payload = json.dumps(payload_obj)
         self.transport.publish(topic, payload, qos=0)
         if self.debug:

--- a/arena/scene.py
+++ b/arena/scene.py
@@ -11,6 +11,8 @@ from datetime import datetime, UTC
 from inspect import signature
 from pathlib import Path
 
+from .delta import deep_diff
+
 import __main__ as main
 
 from .arena_mqtt import ArenaMQTT
@@ -68,6 +70,7 @@ class Scene(ArenaMQTT):
         debug=False,
         cli_args=False,
         headless=False,
+        delta_compression=True,
         **kwargs,
     ):
 
@@ -148,6 +151,10 @@ class Scene(ArenaMQTT):
             # objects that exist in the scene, but this scene instance does not have a reference to
             self.unspecified_object_ids = set()
             self.users = {}  # dict of all users
+
+            # Delta compression: shadow map of last-published data dicts (JSON primitives)
+            self.delta_compression = delta_compression
+            self._last_published_state = {}  # object_id -> data dict
 
             # setup program run info to collect stats
             self.run_info = ProgramRunInfo(
@@ -675,10 +682,61 @@ class Scene(ArenaMQTT):
                     f"ERROR!! Publishing wire rotation data must be in Quaternion units, Euler conversion failed for payload: {payload}"
                 )
 
+            # Delta compression: diff data against last-published state
+            if self.delta_compression:
+                payload = self._apply_delta(payload, action)
+
             self.transport.publish(topic, payload, qos=0)
             if self.debug:
                 self.telemetry.add_event(f"[publish] {topic} {payload}")
             return payload
+
+    def _apply_delta(self, payload_str, action):
+        """Apply delta compression to a JSON payload string.
+
+        Diffs the 'data' sub-object against the last-published state for this
+        object_id. Only changed fields are kept in the outgoing message.
+        The full current data state is stored for future diffs.
+
+        Uses json.loads for parsing, which also provides a free deep copy
+        of the data dict (all primitives, no shared references).
+
+        Args:
+            payload_str: JSON string of the full message.
+            action: Message action (create, update, delete).
+
+        Returns:
+            JSON string with delta-compressed data (or original if not applicable).
+        """
+        msg = json.loads(payload_str)
+        object_id = msg.get("object_id")
+
+        if object_id is None:
+            return payload_str
+
+        if action == "delete":
+            self._last_published_state.pop(object_id, None)
+            return payload_str
+
+        data = msg.get("data")
+        if data is None:
+            return payload_str
+
+        if action == "create" or object_id not in self._last_published_state:
+            # First publish: send full, store state (json.loads gave us a deep copy)
+            self._last_published_state[object_id] = data
+            return payload_str
+
+        # Compute delta against last-published state
+        prev_data = self._last_published_state[object_id]
+        delta = deep_diff(prev_data, data)
+
+        # Store the full current state (already a deep copy from json.loads)
+        self._last_published_state[object_id] = data
+
+        # Re-serialize with only the delta in data
+        msg["data"] = delta
+        return json.dumps(msg)
 
     def get_persisted_obj(self, object_id):
         """Returns a dictionary for a persisted object.

--- a/arena/scene.py
+++ b/arena/scene.py
@@ -52,6 +52,7 @@ class Scene(ArenaMQTT):
     :param bool debug: If true, print a log of all publish messages from this client (optional).
     :param bool cli_args: If true, require CLI standardized parameters (optional).
     :param bool headless: If true, force limited input device auth flow (optional).
+    :param bool delta_compression: If true (default), publish object updates using delta-compressed payloads instead of always sending full object payloads. This is only safe when consumers can reconstruct state from full ``Object.json`` payloads; disable it if downstream consumers require complete object JSON on every update.
     """
 
     def __init__(

--- a/arena/scene.py
+++ b/arena/scene.py
@@ -682,8 +682,11 @@ class Scene(ArenaMQTT):
                     f"ERROR!! Publishing wire rotation data must be in Quaternion units, Euler conversion failed for payload: {payload}"
                 )
 
-            # Delta compression: diff data against last-published state
-            if self.delta_compression:
+            # Delta compression only applies to full object-state publishes.
+            # custom_payload messages may contain partial patches/commands, and
+            # diffing them against the last full state can incorrectly emit
+            # deletions for omitted keys.
+            if self.delta_compression and not custom_payload:
                 payload = self._apply_delta(payload, action)
 
             self.transport.publish(topic, payload, qos=0)

--- a/arena/test_system.py
+++ b/arena/test_system.py
@@ -79,6 +79,7 @@ class ArenaE2ETest:
         self.scene_name = scene_name
 
         # Instantiate scene with mock transport; process headless to avoid user auth interactions
+        # Note: delta_compression=False because recorded traces contain full payloads
         self.scene = Scene(
             host="example.com",
             realm=realm,
@@ -86,6 +87,7 @@ class ArenaE2ETest:
             scene=scene_name,
             transport=self.transport,
             headless=True,
+            delta_compression=False,
             config_data={
                 "ARENADefaults": {
                     "mqttHost": "mqtt.example.com",

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,0 +1,310 @@
+"""Tests for delta compression (arena.delta.deep_diff)."""
+
+import json
+import unittest
+
+from arena.delta import deep_diff
+
+
+class TestDeepDiff(unittest.TestCase):
+    """Unit tests for deep_diff function."""
+
+    def test_identical_objects(self):
+        """Identical dicts should produce empty diff."""
+        d = {"position": {"x": 1, "y": 2, "z": 3}, "color": "#ff0000"}
+        self.assertEqual(deep_diff(d, d.copy()), {})
+
+    def test_position_change(self):
+        """Only changed position fields should appear in diff."""
+        prev = {"position": {"x": 2.965, "y": 1.6, "z": 8.877}, "rotation": {"w": 1, "x": 0, "y": 0, "z": 0}}
+        next_val = {"position": {"x": 2.852, "y": 1.6, "z": 8.88}, "rotation": {"w": 1, "x": 0, "y": 0, "z": 0}}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"position": {"x": 2.852, "z": 8.88}})
+        self.assertNotIn("rotation", diff)
+
+    def test_camera_sequence(self):
+        """Full camera message delta from spec — only position.x and position.z changed."""
+        prev_data = {
+            "arena-user": {
+                "color": "#eca7ef",
+                "displayName": "Ivan",
+                "hasAudio": False,
+                "hasVideo": False,
+                "headModelPath": "/static/models/avatars/DamagedHelmet.glb",
+                "jitsiId": "7210ee23",
+                "presence": "Standard",
+            },
+            "object_type": "camera",
+            "position": {"x": 2.965, "y": 1.6, "z": 8.877},
+            "rotation": {"w": 1, "x": -0.019, "y": 0.013, "z": 0},
+        }
+        next_data = {
+            "arena-user": {
+                "color": "#eca7ef",
+                "displayName": "Ivan",
+                "hasAudio": False,
+                "hasVideo": False,
+                "headModelPath": "/static/models/avatars/DamagedHelmet.glb",
+                "jitsiId": "7210ee23",
+                "presence": "Standard",
+            },
+            "object_type": "camera",
+            "position": {"x": 2.852, "y": 1.6, "z": 8.88},
+            "rotation": {"w": 1, "x": -0.019, "y": 0.013, "z": 0},
+        }
+        diff = deep_diff(prev_data, next_data)
+        self.assertEqual(diff, {"position": {"x": 2.852, "z": 8.88}})
+
+        # Verify the delta is much smaller than the full payload
+        full_size = len(json.dumps(next_data))
+        delta_size = len(json.dumps(diff))
+        self.assertLess(delta_size, full_size / 2)
+
+    def test_null_component_delete(self):
+        """None value (semantic delete) must flow through the diff."""
+        prev = {"object_type": "box", "material": {"color": "#ff0000"}}
+        next_val = {"object_type": "box", "material": None}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"material": None})
+
+    def test_null_to_null_noop(self):
+        """Both prev and next have None for same key → omitted from diff."""
+        prev = {"object_type": "box", "material": None}
+        next_val = {"object_type": "box", "material": None}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {})
+
+    def test_new_field_added(self):
+        """Field in next but not prev should be included."""
+        prev = {"object_type": "box"}
+        next_val = {"object_type": "box", "material": {"color": "#00ff00"}}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"material": {"color": "#00ff00"}})
+
+    def test_field_removed(self):
+        """Field in prev but not next → emitted as None (semantic delete)."""
+        prev = {"object_type": "box", "material": {"color": "#ff0000"}}
+        next_val = {"object_type": "box"}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"material": None})
+
+    def test_nested_partial_change(self):
+        """Only changed fields in nested dicts should appear."""
+        prev = {"material": {"color": "#ff0000", "opacity": 0.5, "transparent": True}}
+        next_val = {"material": {"color": "#00ff00", "opacity": 0.5, "transparent": True}}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"material": {"color": "#00ff00"}})
+
+    def test_array_unchanged(self):
+        """Identical arrays should be omitted from diff."""
+        prev = {"path": [[0, 0, 0], [1, 1, 1]], "object_type": "line"}
+        next_val = {"path": [[0, 0, 0], [1, 1, 1]], "object_type": "line"}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {})
+
+    def test_array_changed(self):
+        """Changed arrays should be included in diff."""
+        prev = {"path": [[0, 0, 0], [1, 1, 1]]}
+        next_val = {"path": [[0, 0, 0], [2, 2, 2]]}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"path": [[0, 0, 0], [2, 2, 2]]})
+
+    def test_deep_nested_diff(self):
+        """3+ levels of nesting should be handled correctly."""
+        prev = {"a": {"b": {"c": {"d": 1, "e": 2}}, "f": 3}}
+        next_val = {"a": {"b": {"c": {"d": 1, "e": 99}}, "f": 3}}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"a": {"b": {"c": {"e": 99}}}})
+
+    def test_empty_dicts(self):
+        """Two empty dicts should produce empty diff."""
+        self.assertEqual(deep_diff({}, {}), {})
+
+    def test_prev_empty(self):
+        """Empty prev means everything in next is new."""
+        next_val = {"position": {"x": 1, "y": 2, "z": 3}}
+        diff = deep_diff({}, next_val)
+        self.assertEqual(diff, next_val)
+
+    def test_next_empty(self):
+        """Empty next means everything in prev is deleted."""
+        prev = {"position": {"x": 1}, "color": "red"}
+        diff = deep_diff(prev, {})
+        self.assertEqual(diff, {"position": None, "color": None})
+
+    def test_type_change_dict_to_primitive(self):
+        """Dict replaced by primitive should include the new value."""
+        prev = {"material": {"color": "#ff0000"}}
+        next_val = {"material": "basic"}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"material": "basic"})
+
+    def test_type_change_primitive_to_dict(self):
+        """Primitive replaced by dict should include the new dict."""
+        prev = {"material": "basic"}
+        next_val = {"material": {"color": "#ff0000"}}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"material": {"color": "#ff0000"}})
+
+    def test_bool_change(self):
+        """Boolean changes should be detected."""
+        prev = {"hasAudio": False, "hasVideo": False}
+        next_val = {"hasAudio": True, "hasVideo": False}
+        diff = deep_diff(prev, next_val)
+        self.assertEqual(diff, {"hasAudio": True})
+
+    def test_float_precision(self):
+        """Float values should be compared with ==."""
+        prev = {"x": 1.0}
+        next_val = {"x": 1.0}
+        self.assertEqual(deep_diff(prev, next_val), {})
+
+        next_val2 = {"x": 1.0000001}
+        diff = deep_diff(prev, next_val2)
+        self.assertEqual(diff, {"x": 1.0000001})
+
+
+class TestDeltaIntegration(unittest.TestCase):
+    """Integration tests for delta compression in publish path.
+
+    Uses Scene._apply_delta directly with crafted JSON strings to test
+    the full create/update/delete lifecycle without MQTT setup.
+    """
+
+    def _make_scene(self):
+        """Create a minimal mock scene with delta compression enabled."""
+        import json
+
+        class MockScene:
+            delta_compression = True
+            _last_published_state = {}
+
+        # Bind _apply_delta from Scene
+        from arena.scene import Scene
+        scene = MockScene()
+        scene._apply_delta = Scene._apply_delta.__get__(scene, MockScene)
+        return scene
+
+    def test_create_always_full(self):
+        """Create action should always send full payload and store state."""
+        scene = self._make_scene()
+        full_msg = {
+            "object_id": "box1",
+            "action": "create",
+            "type": "object",
+            "data": {"object_type": "box", "position": {"x": 1, "y": 2, "z": 3}},
+        }
+        payload = json.dumps(full_msg)
+        result = scene._apply_delta(payload, "create")
+
+        # Should be unchanged (full payload)
+        self.assertEqual(json.loads(result), full_msg)
+        # State should be stored
+        self.assertIn("box1", scene._last_published_state)
+
+    def test_update_first_time_full(self):
+        """First update for unknown object should send full."""
+        scene = self._make_scene()
+        msg = {
+            "object_id": "box2",
+            "action": "update",
+            "type": "object",
+            "data": {"object_type": "box", "position": {"x": 1, "y": 2, "z": 3}},
+        }
+        result = scene._apply_delta(json.dumps(msg), "update")
+        self.assertEqual(json.loads(result), msg)
+        self.assertIn("box2", scene._last_published_state)
+
+    def test_update_with_delta(self):
+        """Second update should only contain changed fields."""
+        scene = self._make_scene()
+
+        # First publish (create)
+        create_msg = {
+            "object_id": "cam1",
+            "action": "create",
+            "type": "object",
+            "data": {
+                "object_type": "camera",
+                "position": {"x": 2.965, "y": 1.6, "z": 8.877},
+                "rotation": {"w": 1, "x": -0.019, "y": 0.013, "z": 0},
+            },
+        }
+        scene._apply_delta(json.dumps(create_msg), "create")
+
+        # Second publish (update with only position change)
+        update_msg = {
+            "object_id": "cam1",
+            "action": "update",
+            "type": "object",
+            "data": {
+                "object_type": "camera",
+                "position": {"x": 2.852, "y": 1.6, "z": 8.88},
+                "rotation": {"w": 1, "x": -0.019, "y": 0.013, "z": 0},
+            },
+        }
+        result = scene._apply_delta(json.dumps(update_msg), "update")
+        result_msg = json.loads(result)
+
+        # data should only have position delta
+        self.assertEqual(result_msg["data"], {"position": {"x": 2.852, "z": 8.88}})
+        # top-level fields preserved
+        self.assertEqual(result_msg["object_id"], "cam1")
+        self.assertEqual(result_msg["action"], "update")
+        self.assertEqual(result_msg["type"], "object")
+
+    def test_delete_clears_state(self):
+        """Delete should clear stored state for the object."""
+        scene = self._make_scene()
+
+        # Create first
+        create_msg = {
+            "object_id": "box3",
+            "action": "create",
+            "data": {"object_type": "box"},
+        }
+        scene._apply_delta(json.dumps(create_msg), "create")
+        self.assertIn("box3", scene._last_published_state)
+
+        # Delete
+        delete_msg = {"object_id": "box3", "action": "delete"}
+        scene._apply_delta(json.dumps(delete_msg), "delete")
+        self.assertNotIn("box3", scene._last_published_state)
+
+    def test_update_after_delete_sends_full(self):
+        """Update after delete should send full (no prior state)."""
+        scene = self._make_scene()
+
+        # Create, then delete
+        msg = {"object_id": "box4", "action": "create", "data": {"object_type": "box", "color": "red"}}
+        scene._apply_delta(json.dumps(msg), "create")
+        scene._apply_delta(json.dumps({"object_id": "box4", "action": "delete"}), "delete")
+
+        # Re-create via update
+        update = {"object_id": "box4", "action": "update", "data": {"object_type": "box", "color": "blue"}}
+        result = json.loads(scene._apply_delta(json.dumps(update), "update"))
+        # Should be full since no prior state
+        self.assertEqual(result["data"], {"object_type": "box", "color": "blue"})
+
+    def test_no_data_field_passthrough(self):
+        """Messages without data field should pass through unchanged."""
+        scene = self._make_scene()
+        msg = {"object_id": "x", "action": "update"}
+        payload = json.dumps(msg)
+        self.assertEqual(scene._apply_delta(payload, "update"), payload)
+
+    def test_empty_delta_heartbeat(self):
+        """Identical consecutive updates should produce empty data {} (heartbeat)."""
+        scene = self._make_scene()
+
+        msg = {"object_id": "hb1", "action": "create", "data": {"object_type": "box"}}
+        scene._apply_delta(json.dumps(msg), "create")
+
+        # Same data again as update
+        update = {"object_id": "hb1", "action": "update", "data": {"object_type": "box"}}
+        result = json.loads(scene._apply_delta(json.dumps(update), "update"))
+        self.assertEqual(result["data"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This removes unchanged keys in `data` on publish, reducing msg size for components that do not change.